### PR TITLE
Add async DB tests and fix VPN_Config relationships

### DIFF
--- a/core/db/models/config.py
+++ b/core/db/models/config.py
@@ -15,12 +15,16 @@ class VPN_Config(Base):
     name: Mapped[str] = mapped_column(String(128), unique=True, nullable=False, index=True)
 
     server_id: Mapped[int] = mapped_column(ForeignKey("server.id"))
-    server: Mapped[Server] = relationship("Server", back_populates="vpn_configs",
-                                          cascade="all, delete-orphan")
+    server: Mapped[Server] = relationship(
+        "Server",
+        back_populates="vpn_configs",
+    )
 
     owner_id: Mapped[int] = mapped_column(ForeignKey("user.id"))
-    owner: Mapped[User] = relationship("User", back_populates="vpn_configs",
-                                       cascade="all, delete-orphan")
+    owner: Mapped[User] = relationship(
+        "User",
+        back_populates="vpn_configs",
+    )
 
     display_name: Mapped[str] = mapped_column(String(128))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from cryptography.fernet import Fernet
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+import pytest_asyncio
+from sqlalchemy.pool import StaticPool
+
+# Ensure environment variables required by settings are present
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+from core.db import Base
+import core.db as db
+
+@pytest.fixture(scope="session")
+def anyio_backend():
+    return "asyncio"
+
+@pytest_asyncio.fixture()
+async def engine():
+    import core.db.models  # noqa
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+@pytest_asyncio.fixture()
+def sessionmaker(engine, monkeypatch):
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    monkeypatch.setattr(db.unit_of_work, "async_session", maker, raising=False)
+    monkeypatch.setattr(db, "async_session", maker, raising=False)
+    monkeypatch.setattr(db, "engine", engine, raising=False)
+    return maker
+
+@pytest_asyncio.fixture()
+async def session(sessionmaker):
+    async with sessionmaker() as session:
+        yield session
+
+

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1,0 +1,103 @@
+import pytest
+from core.db.models import User, Server
+from core.db.repo import UserRepo, ServerRepo, ConfigRepo
+from core.db.unit_of_work import uow
+
+@pytest.mark.asyncio
+async def test_user_repo_get_or_create(session):
+    repo = UserRepo(session)
+    user = await repo.get_or_create(123, username="alice")
+    assert user.id is not None
+    assert user.username == "alice"
+
+    user_again = await repo.get_or_create(123)
+    assert user_again.id == user.id
+
+
+@pytest.mark.asyncio
+async def test_user_repo_search(session):
+    repo = UserRepo(session)
+    await repo.get_or_create(1, username="alice")
+    await repo.get_or_create(2, username="alex")
+    await repo.get_or_create(3, username="bob")
+
+    results = await repo.search_by_username("al")
+    usernames = {u.username for u in results}
+    assert usernames == {"alice", "alex"}
+
+
+@pytest.mark.asyncio
+async def test_server_repo_crud(session):
+    repo = ServerRepo(session)
+    server = await repo.create(
+        name="vpn1",
+        ip="1.1.1.1",
+        port=22,
+        host="host1",
+        location="USA",
+        api_key="secret",
+        cost=10,
+    )
+    assert server.id is not None
+    # api_key is stored encrypted but returned decrypted
+    assert server.api_key == "secret"
+
+    updated = await repo.update(server.id, name="vpn2", location="Canada")
+    assert updated.name == "vpn2"
+    assert updated.location == "Canada"
+
+    by_name = await repo.search_by_name("vpn2")
+    assert by_name[0].id == server.id
+
+    by_loc = await repo.search_by_location("can")
+    assert by_loc[0].id == server.id
+
+
+@pytest.mark.asyncio
+async def test_config_repo(session):
+    user_repo = UserRepo(session)
+    server_repo = ServerRepo(session)
+    config_repo = ConfigRepo(session)
+
+    user = await user_repo.get_or_create(1, username="user")
+    server = await server_repo.create(
+        name="vpn",
+        ip="1.1.1.1",
+        port=22,
+        host="host",
+        location="US",
+        api_key="k",
+        cost=1,
+    )
+    cfg = await config_repo.create(server.id, user.id, "cfg1", "display")
+
+    active = await config_repo.get_active()
+    assert len(active) == 1 and active[0].id == cfg.id
+
+    await config_repo.suspend(cfg.id)
+    assert cfg.suspended is True
+
+    suspended = await config_repo.get_suspended()
+    assert len(suspended) == 1
+
+    await config_repo.unsuspend(cfg.id)
+    assert cfg.suspended is False
+
+
+@pytest.mark.asyncio
+async def test_uow(monkeypatch, engine):
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+    import core.db as db
+
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    monkeypatch.setattr(db, "async_session", maker, raising=False)
+    monkeypatch.setattr(db.unit_of_work, "async_session", maker, raising=False)
+
+    async with uow() as repos:
+        assert set(repos.keys()) == {"users", "servers", "configs"}
+        await repos["users"].add(User(tg_id=1))
+
+    async with maker() as sess:
+        repo = UserRepo(sess)
+        user = await repo.get(tg_id=1)
+        assert user is not None


### PR DESCRIPTION
## Summary
- add async pytest fixtures and tests for database repos and Unit of Work
- fix invalid cascade configuration on VPN_Config relationships

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fff56e36483249045fa3728b937ff