### PR TITLE
Refactor services to be ORM‑agnostic

### DIFF
--- a/core/services/__init__.py
+++ b/core/services/__init__.py
@@ -2,10 +2,14 @@ from .api_gateway import APIGateway
 from .config import ConfigService
 from .server import ServerService
 from .user import UserService
+from .models import Config, Server, User
 
 __all__ = [
     "APIGateway",
     "UserService",
     "ServerService",
     "ConfigService",
+    "Server",
+    "User",
+    "Config",
 ]

--- a/core/services/api_gateway.py
+++ b/core/services/api_gateway.py
@@ -6,7 +6,13 @@ import httpx
 class APIGateway:
     """Thin async wrapper around the remote VPN‑management REST API."""
 
-    def __init__(self, ip: str, port: int, api_key: str, *, timeout: float = 20.0) -> None:
+    def __init__(self, ip: str | object, port: int | None = None, api_key: str | None = None, *, timeout: float = 20.0) -> None:
+        if port is None and hasattr(ip, "ip"):
+            server = ip
+            ip = server.ip
+            port = server.port
+            api_key = server.api_key
+        assert port is not None and api_key is not None
         self._base_url = f"http://{ip}:{port}"
         self._headers = {"X-API-Key": api_key}
         self._timeout = timeout

--- a/core/services/config.py
+++ b/core/services/config.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 from datetime import datetime
-from typing import Any, Mapping, Sequence
+from typing import Callable, Sequence
 
-from core.db.models import VPN_Config
-
+from .models import Config
 from .api_gateway import APIGateway
 
 
 class ConfigService:
     """High‑level operations on *VPN client configurations*."""
 
-    def __init__(self, repos: Mapping[str, Any]) -> None:
-        self._configs = repos["configs"]
-        self._servers = repos["servers"]
+    def __init__(self, uow: Callable) -> None:
+        self._uow = uow
 
     # ---------- CRUD wrappers ----------
 
@@ -22,67 +20,78 @@ class ConfigService:
         server_id: int,
         owner_id: int,
         name: str,
+        display_name: str,
         use_password: bool = False,
-    ) -> VPN_Config:
-        server = await self._servers.get(id=server_id)
-        if not server:
-            raise ValueError(f"Server {server_id} not found")
+    ) -> Config:
+        async with self._uow() as repos:
+            server = await repos["servers"].get(id=server_id)
+            if not server:
+                raise ValueError(f"Server {server_id} not found")
 
-        # provision on remote server first
-        async with APIGateway(server) as api:
-            await api.create_client(name, use_password=use_password)
+            async with APIGateway(server.ip, server.port, server.api_key) as api:
+                await api.create_client(name, use_password=use_password)
 
-        cfg = VPN_Config(
-            name=name,
-            server_id=server_id,
-            owner_id=owner_id,
-            suspended=False,
-            created_at=datetime.now(),
-        )
-        return await self._configs.add(cfg)
+            cfg = await repos["configs"].create(
+                server_id,
+                owner_id,
+                name,
+                display_name,
+            )
+            return Config.from_orm(cfg)
 
     async def download_config(self, config_id: int) -> bytes:
-        cfg = await self._configs.get(id=config_id, joined_load=["server"])
-        if not cfg:
-            raise ValueError("Config not found")
-        async with APIGateway(cfg.server) as api:
-            return await api.download_config(cfg.name)
+        async with self._uow() as repos:
+            cfg = await repos["configs"].get(id=config_id, joined_load=["server"])
+            if not cfg:
+                raise ValueError("Config not found")
+            async with APIGateway(cfg.server.ip, cfg.server.port, cfg.server.api_key) as api:
+                return await api.download_config(cfg.name)
 
     async def revoke_config(self, config_id: int) -> None:
-        cfg = await self._configs.get(id=config_id, joined_load=["server"])
-        if not cfg:
-            raise ValueError("Config not found")
-        async with APIGateway(cfg.server) as api:
-            await api.revoke_client(cfg.name)
-        await self._configs.delete(id=config_id)
+        async with self._uow() as repos:
+            cfg = await repos["configs"].get(id=config_id, joined_load=["server"])
+            if not cfg:
+                raise ValueError("Config not found")
+            async with APIGateway(cfg.server.ip, cfg.server.port, cfg.server.api_key) as api:
+                await api.revoke_client(cfg.name)
+            await repos["configs"].delete(id=config_id)
 
-    async def suspend_config(self, config_id: int) -> VPN_Config:
-        cfg = await self._configs.get(id=config_id, joined_load=["server"])
-        if not cfg:
-            raise ValueError("Config not found")
-        async with APIGateway(cfg.server) as api:
-            await api.suspend_client(cfg.name)
-        return await self._configs.suspend_config(config_id)
+    async def suspend_config(self, config_id: int) -> Config:
+        async with self._uow() as repos:
+            cfg = await repos["configs"].get(id=config_id, joined_load=["server"])
+            if not cfg:
+                raise ValueError("Config not found")
+            async with APIGateway(cfg.server.ip, cfg.server.port, cfg.server.api_key) as api:
+                await api.suspend_client(cfg.name)
+            cfg = await repos["configs"].suspend(config_id)
+            return Config.from_orm(cfg)
 
-    async def unsuspend_config(self, config_id: int) -> VPN_Config:
-        cfg = await self._configs.get(id=config_id, joined_load=["server"])
-        if not cfg:
-            raise ValueError("Config not found")
-        async with APIGateway(cfg.server) as api:
-            await api.unsuspend_client(cfg.name)
-        return await self._configs.unsuspend_config(config_id)
+    async def unsuspend_config(self, config_id: int) -> Config:
+        async with self._uow() as repos:
+            cfg = await repos["configs"].get(id=config_id, joined_load=["server"])
+            if not cfg:
+                raise ValueError("Config not found")
+            async with APIGateway(cfg.server.ip, cfg.server.port, cfg.server.api_key) as api:
+                await api.unsuspend_client(cfg.name)
+            cfg = await repos["configs"].unsuspend(config_id)
+            return Config.from_orm(cfg)
 
-    async def list_active(self, *, owner_id: int | None = None) -> Sequence[VPN_Config]:
-        return await self._configs.get_active_configs(owner_id=owner_id)
+    async def list_active(self, *, owner_id: int | None = None) -> Sequence[Config]:
+        async with self._uow() as repos:
+            configs = await repos["configs"].get_active(owner_id=owner_id)
+            return [Config.from_orm(c) for c in configs]
 
     async def list_suspended(
         self, *, owner_id: int | None = None
-    ) -> Sequence[VPN_Config]:
-        return await self._configs.get_suspended_configs(owner_id=owner_id)
+    ) -> Sequence[Config]:
+        async with self._uow() as repos:
+            configs = await repos["configs"].get_suspended(owner_id=owner_id)
+            return [Config.from_orm(c) for c in configs]
 
     async def list_blocked(self, server_id: int) -> Sequence[str]:
-        server = await self._servers.get(id=server_id)
-        if not server:
-            raise ValueError(f"Server {server_id} not found")
-        async with APIGateway(server) as api:
-            return await api.list_blocked()
+        async with self._uow() as repos:
+            server = await repos["servers"].get(id=server_id)
+            if not server:
+                raise ValueError(f"Server {server_id} not found")
+            async with APIGateway(server.ip, server.port, server.api_key) as api:
+                return await api.list_blocked()

--- a/core/services/models.py
+++ b/core/services/models.py
@@ -1,0 +1,72 @@
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+
+@dataclass
+class Server:
+    id: int
+    name: str
+    ip: str
+    port: int
+    host: str
+    monthly_cost: Decimal
+    location: str
+    api_key: str
+
+    @classmethod
+    def from_orm(cls, obj):
+        return cls(
+            id=obj.id,
+            name=obj.name,
+            ip=obj.ip,
+            port=obj.port,
+            host=obj.host,
+            monthly_cost=getattr(obj, "monthly_cost", obj.cost if hasattr(obj, "cost") else obj.monthly_cost),
+            location=obj.location,
+            api_key=obj.api_key,
+        )
+
+
+@dataclass
+class User:
+    id: int
+    tg_id: int
+    username: str | None
+    created: datetime
+    balance: float
+
+    @classmethod
+    def from_orm(cls, obj):
+        return cls(
+            id=obj.id,
+            tg_id=obj.tg_id,
+            username=obj.username,
+            created=obj.created,
+            balance=obj.balance,
+        )
+
+
+@dataclass
+class Config:
+    id: int
+    name: str
+    server_id: int
+    owner_id: int
+    display_name: str
+    created_at: datetime
+    suspended: bool
+    suspended_at: datetime | None
+
+    @classmethod
+    def from_orm(cls, obj):
+        return cls(
+            id=obj.id,
+            name=obj.name,
+            server_id=obj.server_id,
+            owner_id=obj.owner_id,
+            display_name=obj.display_name,
+            created_at=obj.created_at,
+            suspended=obj.suspended,
+            suspended_at=obj.suspended_at,
+        )

--- a/core/services/server.py
+++ b/core/services/server.py
@@ -1,21 +1,25 @@
 from __future__ import annotations
 
-from typing import Any, Mapping, Sequence
+from typing import Callable, Sequence
 
-from core.db.models import Server
+from .models import Server
 
 
 class ServerService:
-    """Business helpers for **VPN servers** (but not configs)."""
+    """Operations on VPN **servers**."""
 
-    def __init__(self, repos: Mapping[str, Any]) -> None:
-        self._servers = repos["servers"]
+    def __init__(self, uow: Callable) -> None:
+        self._uow = uow
 
     async def get(self, server_id: int) -> Server | None:
-        return await self._servers.get(id=server_id)
+        async with self._uow() as repos:
+            server = await repos["servers"].get(id=server_id)
+            return Server.from_orm(server) if server else None
 
     async def list(self, **filters) -> Sequence[Server]:
-        return await self._servers.list(**filters)
+        async with self._uow() as repos:
+            servers = await repos["servers"].list(**filters)
+            return [Server.from_orm(s) for s in servers]
 
     async def create(
         self,
@@ -27,12 +31,19 @@ class ServerService:
         api_key: str,
         cost: int
     ) -> Server:
-        return await self._servers.create(
-            name=name,
-            ip=ip,
-            port=port,
-            host=host,
-            location=location,
-            api_key=api_key,
-            cost=cost
-        )
+        async with self._uow() as repos:
+            server = await repos["servers"].create(
+                name=name,
+                ip=ip,
+                port=port,
+                host=host,
+                location=location,
+                api_key=api_key,
+                cost=cost,
+            )
+            return Server.from_orm(server)
+
+    async def delete(self, server_id: int) -> bool:
+        async with self._uow() as repos:
+            deleted = await repos["servers"].delete(id=server_id)
+            return bool(deleted)

--- a/core/services/user.py
+++ b/core/services/user.py
@@ -1,17 +1,37 @@
 from __future__ import annotations
-from typing import Any, Mapping
 
-from core.db.models import User
+from typing import Callable
+
+from .models import User
 
 
 class UserService:
-    """Business‑logic helpers around **users**."""
+    """High level operations for **users**."""
 
-    def __init__(self, repos: Mapping[str, Any]) -> None:
-        self._users = repos["users"]
+    def __init__(self, uow: Callable):
+        """Store callable returning UnitOfWork."""
+        self._uow = uow
 
-    async def get_or_create_user(self, tg_id: int, **kw) -> User:
-        return await self._users.get_or_create(tg_id, **kw)
+    async def register(self, tg_id: int, **kw) -> User:
+        async with self._uow() as repos:
+            user = await repos["users"].get_or_create(tg_id, **kw)
+            return User.from_orm(user)
+
+    async def delete(self, user_id: int) -> bool:
+        async with self._uow() as repos:
+            user = await repos["users"].get(id=user_id)
+            if not user:
+                return False
+
+            configs = await repos["configs"].list(owner_id=user_id)
+            for cfg in configs:
+                if not cfg.suspended:
+                    await repos["configs"].suspend(cfg.id)
+
+            await repos["users"].delete(id=user_id)
+            return True
 
     async def get(self, user_id: int) -> User | None:
-        return await self._users.get(id=user_id)
+        async with self._uow() as repos:
+            user = await repos["users"].get(id=user_id)
+            return User.from_orm(user) if user else None

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,70 @@
+import pytest
+
+from core.services import UserService, ServerService, ConfigService
+from core.db.unit_of_work import uow
+
+class DummyGateway:
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def create_client(self, name, use_password=False):
+        pass
+    async def download_config(self, name):
+        return b"data"
+    async def revoke_client(self, name):
+        pass
+    async def suspend_client(self, name):
+        pass
+    async def unsuspend_client(self, name):
+        pass
+    async def list_blocked(self):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_services_workflow(monkeypatch, sessionmaker):
+    monkeypatch.setattr("core.services.config.APIGateway", lambda *a, **kw: DummyGateway())
+
+    server_svc = ServerService(uow)
+    user_svc = UserService(uow)
+    config_svc = ConfigService(uow)
+
+    # create user and server
+    user = await user_svc.register(100)
+    server = await server_svc.create(
+        name="srv",
+        ip="1.1.1.1",
+        port=22,
+        host="host",
+        location="US",
+        api_key="k",
+        cost=1,
+    )
+
+    # create config
+    cfg = await config_svc.create_config(
+        server_id=server.id,
+        owner_id=user.id,
+        name="cfg1",
+        display_name="disp",
+    )
+
+    # suspend/unsuspend
+    await config_svc.suspend_config(cfg.id)
+    sus = await config_svc.list_suspended(owner_id=user.id)
+    assert len(sus) == 1 and sus[0].id == cfg.id
+
+    await config_svc.unsuspend_config(cfg.id)
+    active = await config_svc.list_active(owner_id=user.id)
+    assert len(active) == 1 and active[0].id == cfg.id
+
+    # delete user -> config suspended but kept
+    await user_svc.delete(user.id)
+    sus2 = await config_svc.list_suspended(owner_id=user.id)
+    assert len(sus2) == 1 and sus2[0].id == cfg.id
+
+    # delete server -> config removed
+    await server_svc.delete(server.id)
+    async with uow() as repos:
+        assert await repos["configs"].get(id=cfg.id) is None


### PR DESCRIPTION
## Summary
- introduce dataclass models for service layer
- rewrite UserService, ServerService and ConfigService to use Unit of Work
- allow `APIGateway` to be instantiated from a server object
- expose dataclass models in `core.services`
- add integration tests for new service layer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c7d7cf408324832607bb4b0ca6a0