### PR TITLE
Implement balance checks and billing daemon

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -5,6 +5,8 @@ class Settings(BaseSettings):
     database_url: str
     encryption_key: str
     bot_token: str = ""
+    per_config_cost: float = 1.0
+    billing_interval: int = 3600
 
     class Config:
         env_file = '.env'

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -1,0 +1,3 @@
+class InsufficientBalanceError(Exception):
+    """Raised when user's balance is insufficient for an operation."""
+

--- a/core/services/config.py
+++ b/core/services/config.py
@@ -4,6 +4,7 @@ from typing import Callable, Sequence
 
 from .api_gateway import APIGateway
 from .models import Config
+from core.exceptions import InsufficientBalanceError
 
 
 class ConfigService:
@@ -27,6 +28,12 @@ class ConfigService:
             server = await repos["servers"].get(id=server_id)
             if not server:
                 raise ValueError(f"Server {server_id} not found")
+
+            user = await repos["users"].get(id=owner_id)
+            if not user:
+                raise ValueError(f"User {owner_id} not found")
+            if user.balance <= 0:
+                raise InsufficientBalanceError("Insufficient balance")
 
             async with APIGateway(server.ip, server.port, server.api_key) as api:
                 await api.create_client(name, use_password=use_password)

--- a/scripts/billing_daemon.py
+++ b/scripts/billing_daemon.py
@@ -1,0 +1,20 @@
+import sys
+import os
+
+# Ensure project root is on path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import asyncio
+
+from core.config import settings
+from core.services import BillingService
+from core.db.unit_of_work import uow
+
+async def run():
+    billing = BillingService(uow, per_config_cost=settings.per_config_cost)
+    while True:
+        await billing.charge_all()
+        await asyncio.sleep(settings.billing_interval)
+
+if __name__ == "__main__":
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add `InsufficientBalanceError` exception and check balance before config creation
- include new `per_config_cost` and `billing_interval` settings
- expose `billing_daemon` script to periodically charge users
- support `/topup` command and handle balance errors in the bot
- test that configs cannot be created with zero balance

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842003c82d4832488a42235136e096d