### PR TITLE
Add user list and detail pages to admin

### DIFF
--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -5,12 +5,21 @@
   <title>VPN Admin</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
-<body class="container mt-4">
-  <nav class="mb-3">
-    <a class="btn btn-secondary" href="{{ url_for('index') }}">Home</a>
-    <a class="btn btn-secondary" href="{{ url_for('list_servers') }}">Servers</a>
-    <a class="btn btn-secondary" href="{{ url_for('list_configs') }}">Configs</a>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <div class="container">
+      <a class="navbar-brand" href="{{ url_for('index') }}">VPN Admin</a>
+      <div class="collapse navbar-collapse">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('list_servers') }}">Servers</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('list_configs') }}">Configs</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('list_users') }}">Users</a></li>
+        </ul>
+      </div>
+    </div>
   </nav>
-  {% block body %}{% endblock %}
+  <div class="container mt-4">
+    {% block body %}{% endblock %}
+  </div>
 </body>
 </html>

--- a/admin/templates/index.html
+++ b/admin/templates/index.html
@@ -1,4 +1,4 @@
 {% extends 'base.html' %}
 {% block body %}
-<p>Use the navigation links above to manage servers and configs.</p>
+<p>Use the navigation links above to manage servers, configs and users.</p>
 {% endblock %}

--- a/admin/templates/user_detail.html
+++ b/admin/templates/user_detail.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+{% block body %}
+<h2>User {{ user.id }}</h2>
+<ul class="list-group mb-3">
+  <li class="list-group-item"><strong>Telegram ID:</strong> {{ user.tg_id }}</li>
+  <li class="list-group-item"><strong>Username:</strong> {{ user.username or '' }}</li>
+  <li class="list-group-item"><strong>Balance:</strong> {{ '%.2f'|format(user.balance) }}</li>
+  <li class="list-group-item"><strong>Created:</strong> {{ user.created }}</li>
+</ul>
+<h3>Configs</h3>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Name</th>
+      <th>Server</th>
+      <th>Suspended</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for c in configs %}
+    <tr>
+      <td>{{ c.id }}</td>
+      <td>{{ c.name }}</td>
+      <td>{{ c.server_id }}</td>
+      <td>{{ 'Yes' if c.suspended else 'No' }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/admin/templates/users.html
+++ b/admin/templates/users.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% block body %}
+<h2>Users</h2>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Telegram ID</th>
+      <th>Username</th>
+      <th>Balance</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for u in users %}
+    <tr>
+      <td>{{ u.id }}</td>
+      <td>{{ u.tg_id }}</td>
+      <td>{{ u.username or '' }}</td>
+      <td>{{ '%.2f'|format(u.balance) }}</td>
+      <td><a class="btn btn-sm btn-primary" href="{{ url_for('view_user', user_id=u.id) }}">View</a></td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/core/services/user.py
+++ b/core/services/user.py
@@ -35,3 +35,9 @@ class UserService:
         async with self._uow() as repos:
             user = await repos["users"].get(id=user_id)
             return User.from_orm(user) if user else None
+
+    async def list(self) -> list[User]:
+        """Return all users."""
+        async with self._uow() as repos:
+            users = await repos["users"].list()
+            return [User.from_orm(u) for u in users]


### PR DESCRIPTION
## Summary
- improve navbar layout in admin
- list all users with link to view details
- show individual user info and their configs
- expose new `list` method in `UserService`

## Testing
- `pip install -r requirements.txt`
- `pip install pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e79d073c8324882d3d75e98c0977