### PR TITLE
Add env file usage for compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# PostgreSQL settings
+POSTGRES_DB=vpn
+POSTGRES_USER=vpn
+POSTGRES_PASSWORD=vpn
+
+# Application settings
+DATABASE_URL=postgresql+asyncpg://vpn:vpn@db:5432/vpn
+ENCRYPTION_KEY=change_me
+BOT_TOKEN=change_me
+PER_CONFIG_COST=1.0
+BILLING_INTERVAL=3600
+ADMIN_PASSWORD=admin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PYTHONPATH=/app
+
+CMD ["python", "-m", "bot.main"]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ python scripts/init_db.py
 
 ## Configuration
 
-All settings are read from environment variables (see `core/config.py`):
+All settings are read from environment variables (see `core/config.py`).
+Create a `.env` file (see `.env.example`) to provide them:
 
 - `DATABASE_URL` – database connection string
 - `ENCRYPTION_KEY` – Fernet key used to encrypt server API keys
@@ -70,3 +71,24 @@ pytest
 - Temporary configuration files created by the bot are placed in the system temp directory and removed immediately after sending.
 - Communication with VPN servers is performed over plain HTTP; ensure your environment is trusted or switch to HTTPS.
 
+
+## Deployment with Docker
+
+A `docker-compose.yml` file is included to run the full stack with PostgreSQL.
+Build the images and initialize the database first:
+
+```bash
+docker compose build
+docker compose run --rm bot python scripts/init_db.py
+```
+
+Then start all services in the background:
+
+```bash
+docker compose up -d
+```
+
+Copy `.env.example` to `.env` and adjust the values (such as `BOT_TOKEN`,
+`ENCRYPTION_KEY` and `ADMIN_PASSWORD`) for your production setup. Docker
+Compose will pick them up automatically. The admin panel will be available on
+port 5000.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+version: "3.8"
+
+services:
+  db:
+    image: postgres:16
+    restart: always
+    env_file: .env
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  bot:
+    build: .
+    command: python -m bot.main
+    env_file: .env
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      BOT_TOKEN: ${BOT_TOKEN}
+      PER_CONFIG_COST: ${PER_CONFIG_COST}
+      BILLING_INTERVAL: ${BILLING_INTERVAL}
+
+  admin:
+    build: .
+    command: python -m admin.app
+    env_file: .env
+    ports:
+      - "5000:5000"
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD}
+
+  billing:
+    build: .
+    command: python scripts/billing_daemon.py
+    env_file: .env
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      PER_CONFIG_COST: ${PER_CONFIG_COST}
+      BILLING_INTERVAL: ${BILLING_INTERVAL}
+
+volumes:
+  db_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,5 @@ typing-inspection==0.4.1
 typing_extensions==4.14.0
 yarl==1.20.0
 flask==3.0.3
+
+asyncpg==0.29.0


### PR DESCRIPTION
## Summary
- allow docker-compose services to read environment variables from `.env`
- provide `.env.example` with default values
- update deployment docs for `.env` configuration

## Testing
- `pip install -r requirements.txt`
- `pip install pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ee0a200483248a1bfa8c4c38845e