### PR TITLE
Add separate CI build and deploy workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build and Push
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -r requirements.txt
+      - run: pytest -q
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.REGISTRY_USERNAME }}/vpn:latest
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy to Server
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Copy compose file
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          source: docker-compose.yml
+          target: /opt/vpn
+      - name: Execute remote commands
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            cd /opt/vpn
+            export IMAGE=${{ secrets.REGISTRY_USERNAME }}/vpn:latest
+            docker compose pull
+            docker compose down
+            docker compose up -d
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 ENV PYTHONPATH=/app
+EXPOSE 5000
 
 CMD ["python", "-m", "bot.main"]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Located in [`admin/`](admin). It exposes a minimal HTML interface to manage serv
 python -m admin.app
 ```
 
-and open `http://localhost:5000`.
+and open `http://localhost:14081`.
 
 ### Billing daemon
 
@@ -91,4 +91,4 @@ docker compose up -d
 Copy `.env.example` to `.env` and adjust the values (such as `BOT_TOKEN`,
 `ENCRYPTION_KEY` and `ADMIN_PASSWORD`) for your production setup. Docker
 Compose will pick them up automatically. The admin panel will be available on
-port 5000.
+port 14081 (forwarded to 5000 in the container).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - db_data:/var/lib/postgresql/data
 
   bot:
+    image: ${IMAGE:-vpn}
     build: .
     command: python -m bot.main
     env_file: .env
@@ -26,11 +27,12 @@ services:
       BILLING_INTERVAL: ${BILLING_INTERVAL}
 
   admin:
+    image: ${IMAGE:-vpn}
     build: .
     command: python -m admin.app
     env_file: .env
     ports:
-      - "5000:5000"
+      - "14081:5000"
     depends_on:
       - db
     environment:
@@ -39,6 +41,7 @@ services:
       ADMIN_PASSWORD: ${ADMIN_PASSWORD}
 
   billing:
+    image: ${IMAGE:-vpn}
     build: .
     command: python scripts/billing_daemon.py
     env_file: .env

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ pydantic-settings==2.9.1
 pydantic_core==2.33.2
 Pygments==2.19.1
 pytest==8.4.0
+pytest-asyncio==0.23.6
 python-dotenv==1.1.0
 sniffio==1.3.1
 SQLAlchemy==2.0.41


### PR DESCRIPTION
## Summary
- use a single Docker image for all services
- expose admin service on port 14081
- document new port mapping
- split workflows into `build.yml` and `deploy.yml`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842f2b9f188832498be7e176c083510