### PR TITLE
Fix DB init credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ POSTGRES_USER=vpn
 POSTGRES_PASSWORD=vpn
 
 # Application settings
+# Used only when running without Docker Compose; compose derives it automatically
 DATABASE_URL=postgresql+asyncpg://vpn:vpn@db:5432/vpn
 ENCRYPTION_KEY=change_me
 BOT_TOKEN=change_me

--- a/README.md
+++ b/README.md
@@ -44,9 +44,12 @@ python scripts/init_db.py
 ## Configuration
 
 All settings are read from environment variables (see `core/config.py`).
-Create a `.env` file (see `.env.example`) to provide them:
+Create a `.env` file (see `.env.example`) to provide them.
+When using Docker Compose the `DATABASE_URL` value is generated automatically
+from the PostgreSQL credentials, otherwise set it manually:
 
-- `DATABASE_URL` – database connection string
+- `DATABASE_URL` – database connection string (only required when running
+  without Docker Compose)
 - `ENCRYPTION_KEY` – Fernet key used to encrypt server API keys
 - `BOT_TOKEN` – Telegram bot token
 - `PER_CONFIG_COST` – how much to charge per active config (default `1.0`)
@@ -89,6 +92,7 @@ docker compose up -d
 ```
 
 Copy `.env.example` to `.env` and adjust the values (such as `BOT_TOKEN`,
-`ENCRYPTION_KEY` and `ADMIN_PASSWORD`) for your production setup. Docker
-Compose will pick them up automatically. The admin panel will be available on
+`ENCRYPTION_KEY`, `POSTGRES_USER` and `POSTGRES_PASSWORD`) for your production
+setup. Docker Compose will pick them up automatically and derive `DATABASE_URL`
+from them. The admin panel will be available on
 port 5000.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     depends_on:
       - db
     environment:
-      DATABASE_URL: ${DATABASE_URL}
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY}
       BOT_TOKEN: ${BOT_TOKEN}
       PER_CONFIG_COST: ${PER_CONFIG_COST}
@@ -36,7 +36,7 @@ services:
     depends_on:
       - db
     environment:
-      DATABASE_URL: ${DATABASE_URL}
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD}
 
@@ -48,7 +48,7 @@ services:
     depends_on:
       - db
     environment:
-      DATABASE_URL: ${DATABASE_URL}
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY}
       PER_CONFIG_COST: ${PER_CONFIG_COST}
       BILLING_INTERVAL: ${BILLING_INTERVAL}


### PR DESCRIPTION
## Summary
- make database URL derive from the provided PostgreSQL env vars
- clarify `.env` usage in example and docs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68434423e2308324afc2dfd723e45428