### PR TITLE
Fix pkg_resources import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,5 +42,5 @@ typing-inspection==0.4.1
 typing_extensions==4.14.0
 yarl==1.20.0
 sanic==23.12.2
-
+setuptools>=65.5
 asyncpg==0.29.0


### PR DESCRIPTION
## Summary
- add setuptools dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843ed6b03cc8324b5e1fb6c1aa9d191