### PR TITLE
Improve config management commands

### DIFF
--- a/core/services/config.py
+++ b/core/services/config.py
@@ -85,6 +85,12 @@ class ConfigService:
             cfg = await repos["configs"].unsuspend(config_id)
             return Config.from_orm(cfg)
 
+    async def get(self, config_id: int) -> Config | None:
+        """Return a single config by ID or ``None`` if missing."""
+        async with self._uow() as repos:
+            cfg = await repos["configs"].get(id=config_id)
+            return Config.from_orm(cfg) if cfg else None
+
     async def suspend_all(self, owner_id: int) -> int:
         """Suspend all active configs for a user and return count."""
         async with self._uow() as repos:


### PR DESCRIPTION
## Summary
- list both active and suspended configs in `/configs` command
- allow users to view config info and manage it via callbacks
- check balance before unsuspending
- expose `get` method in `ConfigService`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a2bebb58832492195538616756b9