### PR TITLE
Implement paid config creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,6 @@ DATABASE_URL=postgresql+asyncpg://vpn:vpn@db:5432/vpn
 ENCRYPTION_KEY=change_me
 BOT_TOKEN=change_me
 PER_CONFIG_COST=1.0
+CONFIG_CREATION_COST=10.0
 BILLING_INTERVAL=3600
 ADMIN_API_KEY=secret_key

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ from the PostgreSQL credentials, otherwise set it manually:
 - `ENCRYPTION_KEY` – Fernet key used to encrypt server API keys
 - `BOT_TOKEN` – Telegram bot token
 - `PER_CONFIG_COST` – how much to charge per active config (default `1.0`)
+- `CONFIG_CREATION_COST` – cost charged when a config is created (default `10.0`)
 - `BILLING_INTERVAL` – seconds between periodic charges
 - `ADMIN_API_KEY` – API key required in the `X-API-Key` header (leave empty to disable auth)
 

--- a/admin/app.py
+++ b/admin/app.py
@@ -108,12 +108,13 @@ async def list_configs(request: Request):
 @auth_required
 async def create_config(request: Request):
     data = parse(ConfigCreate, request)
-    cfg = await config_service.create_config(
+    cfg = await billing_service.create_paid_config(
         server_id=data.server_id,
         owner_id=data.owner_id,
         name=data.name,
         display_name=data.display_name or data.name,
         use_password=data.use_password,
+        creation_cost=settings.config_creation_cost,
     )
     return json(serialize_dataclass(cfg))
 

--- a/core/config.py
+++ b/core/config.py
@@ -6,6 +6,7 @@ class Settings(BaseSettings):
     encryption_key: str
     bot_token: str = ""
     per_config_cost: float = 1.0
+    config_creation_cost: float = 10.0
     billing_interval: int = 3600
     admin_api_key: str = ""
 

--- a/core/services/billing.py
+++ b/core/services/billing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Callable, Sequence
 
-from core.exceptions import UserNotFoundError
+from core.exceptions import UserNotFoundError, InsufficientBalanceError
 
 from .config import ConfigService
 from .models import User
@@ -53,3 +53,48 @@ class BillingService:
 
             if new_balance <= 0 and charge:
                 await self._config_service.suspend_all(user.id)
+
+    async def withdraw(self, user_id: int, amount: float) -> User:
+        """Deduct ``amount`` from user's balance and return updated user."""
+        async with self._uow() as repos:
+            user = await repos["users"].get(id=user_id)
+            if not user:
+                raise UserNotFoundError(f"User with ID {user_id} not found")
+            if user.balance < amount:
+                raise InsufficientBalanceError("Insufficient balance")
+            new_balance = user.balance - amount
+            user = await repos["users"].update(user_id, balance=new_balance)
+
+        if new_balance <= 0:
+            await self._config_service.suspend_all(user_id)
+
+        return User.from_orm(user)
+
+    async def create_paid_config(
+        self,
+        *,
+        server_id: int,
+        owner_id: int,
+        name: str,
+        display_name: str,
+        creation_cost: float,
+        use_password: bool = False,
+    ) -> "Config":
+        """Create config and charge ``creation_cost`` on success."""
+        async with self._uow() as repos:
+            user = await repos["users"].get(id=owner_id)
+            if not user:
+                raise UserNotFoundError(f"User with ID {owner_id} not found")
+            if user.balance < creation_cost:
+                raise InsufficientBalanceError("Insufficient balance")
+
+        cfg = await self._config_service.create_config(
+            server_id=server_id,
+            owner_id=owner_id,
+            name=name,
+            display_name=display_name,
+            use_password=use_password,
+        )
+
+        await self.withdraw(owner_id, creation_cost)
+        return cfg

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -44,11 +44,12 @@ async def test_create_requires_balance(monkeypatch, sessionmaker):
     )
 
     with pytest.raises(InsufficientBalanceError):
-        await config_svc.create_config(
+        await billing.create_paid_config(
             server_id=server.id,
             owner_id=user.id,
             name="bal",
             display_name="disp",
+            creation_cost=10,
         )
 
 
@@ -73,14 +74,15 @@ async def test_services_workflow(monkeypatch, sessionmaker):
         cost=1,
     )
 
-    await billing.top_up(user.id, 1)
+    await billing.top_up(user.id, 20)
 
     # create config
-    cfg = await config_svc.create_config(
+    cfg = await billing.create_paid_config(
         server_id=server.id,
         owner_id=user.id,
         name="cfg1",
         display_name="disp",
+        creation_cost=10,
     )
 
     # suspend/unsuspend
@@ -123,19 +125,21 @@ async def test_billing(monkeypatch, sessionmaker):
         cost=1,
     )
 
-    await billing.top_up(user.id, 10)
+    await billing.top_up(user.id, 30)
 
-    await config_svc.create_config(
+    await billing.create_paid_config(
         server_id=server.id,
         owner_id=user.id,
         name="c1",
         display_name="d1",
+        creation_cost=10,
     )
-    await config_svc.create_config(
+    await billing.create_paid_config(
         server_id=server.id,
         owner_id=user.id,
         name="c2",
         display_name="d2",
+        creation_cost=10,
     )
 
     await billing.charge_all()
@@ -164,13 +168,14 @@ async def test_billing_suspend_unsuspend(monkeypatch, sessionmaker):
         cost=1,
     )
 
-    await billing.top_up(user.id, 3)
+    await billing.top_up(user.id, 13)
 
-    cfg = await config_svc.create_config(
+    cfg = await billing.create_paid_config(
         server_id=server.id,
         owner_id=user.id,
         name="c3",
         display_name="d3",
+        creation_cost=10,
     )
 
     await billing.charge_all()
@@ -198,15 +203,16 @@ async def test_server_update_and_user_with_configs(monkeypatch, sessionmaker):
         name="srv4", ip="1.1.1.1", port=22, host="host", location="US", api_key="k", cost=1
     )
 
-    await billing.top_up(user.id, 2)
+    await billing.top_up(user.id, 20)
 
     await server_svc.update(server.id, name="newname")
 
-    cfg = await config_svc.create_config(
+    cfg = await billing.create_paid_config(
         server_id=server.id,
         owner_id=user.id,
         name="cfg4",
         display_name="d4",
+        creation_cost=10,
     )
 
     user_data, configs = await user_svc.get_with_configs(user.id)


### PR DESCRIPTION
## Summary
- charge users a creation fee when generating configs
- expose CONFIG_CREATION_COST setting
- deduct fee through new BillingService methods
- update admin API, bot and tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68469fe7f4508324ae721593c87397aa