### PR TITLE
Add full admin frontend

### DIFF
--- a/admin_frontend/index.html
+++ b/admin_frontend/index.html
@@ -5,9 +5,14 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Admin Frontend</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/admin_frontend/src/App.css
+++ b/admin_frontend/src/App.css
@@ -26,11 +26,3 @@ button {
   margin-top: 10px;
 }
 
-.dashboard {
-  padding: 20px;
-}
-
-.server-list {
-  margin-top: 20px;
-  text-align: left;
-}

--- a/admin_frontend/src/Configs.jsx
+++ b/admin_frontend/src/Configs.jsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react'
+
+const apiUrl = import.meta.env.VITE_ADMIN_API_URL
+const apiKey = import.meta.env.VITE_ADMIN_API_KEY
+
+export default function Configs() {
+  const [configs, setConfigs] = useState([])
+  const [filters, setFilters] = useState({ server_id: '', owner_id: '', suspended: '' })
+  const [error, setError] = useState('')
+
+  const fetchConfigs = async (params = {}) => {
+    const qs = new URLSearchParams(params).toString()
+    try {
+      const res = await fetch(`${apiUrl}/api/configs?${qs}`, {
+        headers: { 'X-API-Key': apiKey },
+      })
+      if (!res.ok) throw new Error('Failed to fetch configs')
+      setConfigs(await res.json())
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  useEffect(() => {
+    fetchConfigs()
+  }, [])
+
+  const handleChange = (e) => {
+    setFilters({ ...filters, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    const params = {}
+    if (filters.server_id) params.server_id = filters.server_id
+    if (filters.owner_id) params.owner_id = filters.owner_id
+    if (filters.suspended !== '') params.suspended = filters.suspended
+    fetchConfigs(params)
+  }
+
+  return (
+    <div className="container mt-3">
+      <h3>Configs</h3>
+      {error && <div className="alert alert-danger">{error}</div>}
+      <form className="row g-2" onSubmit={handleSubmit}>
+        <div className="col-md-2">
+          <input name="server_id" value={filters.server_id} onChange={handleChange} className="form-control" placeholder="Server id" />
+        </div>
+        <div className="col-md-2">
+          <input name="owner_id" value={filters.owner_id} onChange={handleChange} className="form-control" placeholder="Owner id" />
+        </div>
+        <div className="col-md-2">
+          <select name="suspended" value={filters.suspended} onChange={handleChange} className="form-select">
+            <option value="">Any</option>
+            <option value="true">Suspended</option>
+            <option value="false">Active</option>
+          </select>
+        </div>
+        <div className="col-md-2">
+          <button className="btn btn-primary" type="submit">Filter</button>
+        </div>
+      </form>
+      <div className="d-flex flex-wrap mt-4">
+        {configs.map((c) => (
+          <div className="card m-2" style={{ minWidth: '18rem' }} key={c.id}>
+            <div className="card-body">
+              <h5 className="card-title">{c.name}</h5>
+              <p className="card-text">
+                Owner: {c.owner_id} | Server: {c.server_id}
+                <br />
+                Suspended: {String(c.suspended)}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+

--- a/admin_frontend/src/Dashboard.jsx
+++ b/admin_frontend/src/Dashboard.jsx
@@ -1,50 +1,28 @@
-import { useEffect, useState } from 'react'
-
-const apiUrl = import.meta.env.VITE_ADMIN_API_URL
-const apiKey = import.meta.env.VITE_ADMIN_API_KEY
+import { useState } from 'react'
+import Servers from './Servers'
+import Users from './Users'
+import Configs from './Configs'
 
 export default function Dashboard({ onLogout }) {
-  const [servers, setServers] = useState([])
-  const [error, setError] = useState('')
-
-  useEffect(() => {
-    async function fetchServers() {
-      try {
-        const res = await fetch(`${apiUrl}/api/servers`, {
-          headers: { 'X-API-Key': apiKey },
-        })
-        if (!res.ok) {
-          throw new Error('Failed to fetch servers')
-        }
-        const data = await res.json()
-        setServers(data)
-      } catch (err) {
-        setError(err.message)
-      }
-    }
-    fetchServers()
-  }, [])
-
-  const handleLogout = () => {
-    localStorage.removeItem('loggedIn')
-    onLogout()
-  }
+  const [page, setPage] = useState('servers')
 
   return (
-    <div className="dashboard">
-      <h2>Admin Panel</h2>
-      <button onClick={handleLogout}>Logout</button>
-      {error && <div className="error">{error}</div>}
-      <div className="server-list">
-        <h3>Servers</h3>
-        <ul>
-          {servers.map((srv) => (
-            <li key={srv.id}>
-              {srv.name} ({srv.location})
-            </li>
-          ))}
-        </ul>
-      </div>
+    <div>
+      <nav className="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div className="container-fluid">
+          <span className="navbar-brand">Admin</span>
+          <div className="navbar-nav">
+            <button className="nav-link btn btn-link" onClick={() => setPage('servers')}>Servers</button>
+            <button className="nav-link btn btn-link" onClick={() => setPage('users')}>Users</button>
+            <button className="nav-link btn btn-link" onClick={() => setPage('configs')}>Configs</button>
+            <button className="nav-link btn btn-link" onClick={() => { localStorage.removeItem('loggedIn'); onLogout() }}>Logout</button>
+          </div>
+        </div>
+      </nav>
+      {page === 'servers' && <Servers />}
+      {page === 'users' && <Users />}
+      {page === 'configs' && <Configs />}
     </div>
   )
 }
+

--- a/admin_frontend/src/Servers.jsx
+++ b/admin_frontend/src/Servers.jsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from 'react'
+
+const apiUrl = import.meta.env.VITE_ADMIN_API_URL
+const apiKey = import.meta.env.VITE_ADMIN_API_KEY
+
+export default function Servers() {
+  const empty = { name: '', ip: '', port: 22, host: '', location: '', api_key: '', cost: 0 }
+  const [servers, setServers] = useState([])
+  const [form, setForm] = useState(empty)
+  const [error, setError] = useState('')
+
+  const fetchServers = async () => {
+    try {
+      const res = await fetch(`${apiUrl}/api/servers`, {
+        headers: { 'X-API-Key': apiKey },
+      })
+      if (!res.ok) throw new Error('Failed to fetch servers')
+      setServers(await res.json())
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  useEffect(() => {
+    fetchServers()
+  }, [])
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const createServer = async (e) => {
+    e.preventDefault()
+    try {
+      const res = await fetch(`${apiUrl}/api/servers`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-API-Key': apiKey,
+        },
+        body: JSON.stringify({
+          ...form,
+          port: Number(form.port),
+          cost: Number(form.cost),
+        }),
+      })
+      if (!res.ok) throw new Error('Failed to create server')
+      setForm(empty)
+      fetchServers()
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  const deleteServer = async (id) => {
+    if (!confirm('Delete server?')) return
+    await fetch(`${apiUrl}/api/servers/${id}`, {
+      method: 'DELETE',
+      headers: { 'X-API-Key': apiKey },
+    })
+    fetchServers()
+  }
+
+  const editServer = async (srv) => {
+    const name = prompt('Name', srv.name)
+    if (name === null) return
+    const location = prompt('Location', srv.location)
+    if (location === null) return
+    const host = prompt('Host', srv.host)
+    if (host === null) return
+    const ip = prompt('IP', srv.ip)
+    if (ip === null) return
+    const port = prompt('Port', srv.port)
+    if (port === null) return
+    const cost = prompt('Cost', srv.cost)
+    if (cost === null) return
+    await fetch(`${apiUrl}/api/servers/${srv.id}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': apiKey,
+      },
+      body: JSON.stringify({ name, location, host, ip, port: Number(port), cost: Number(cost) }),
+    })
+    fetchServers()
+  }
+
+  return (
+    <div className="container mt-3">
+      <h3>Servers</h3>
+      {error && <div className="alert alert-danger">{error}</div>}
+      <form className="row g-2" onSubmit={createServer}>
+        <div className="col-md-2">
+          <input name="name" value={form.name} onChange={handleChange} className="form-control" placeholder="Name" required />
+        </div>
+        <div className="col-md-2">
+          <input name="ip" value={form.ip} onChange={handleChange} className="form-control" placeholder="IP" required />
+        </div>
+        <div className="col-md-1">
+          <input name="port" value={form.port} onChange={handleChange} className="form-control" placeholder="Port" />
+        </div>
+        <div className="col-md-2">
+          <input name="host" value={form.host} onChange={handleChange} className="form-control" placeholder="Host" required />
+        </div>
+        <div className="col-md-2">
+          <input name="location" value={form.location} onChange={handleChange} className="form-control" placeholder="Location" required />
+        </div>
+        <div className="col-md-2">
+          <input name="api_key" value={form.api_key} onChange={handleChange} className="form-control" placeholder="API key" required />
+        </div>
+        <div className="col-md-1">
+          <input name="cost" value={form.cost} onChange={handleChange} className="form-control" placeholder="Cost" />
+        </div>
+        <div className="col-md-12">
+          <button className="btn btn-primary" type="submit">Add server</button>
+        </div>
+      </form>
+      <div className="d-flex flex-wrap mt-4">
+        {servers.map((srv) => (
+          <div className="card m-2" style={{ minWidth: '18rem' }} key={srv.id}>
+            <div className="card-body">
+              <h5 className="card-title">{srv.name}</h5>
+              <h6 className="card-subtitle mb-2 text-muted">{srv.location}</h6>
+              <p className="card-text">
+                Host: {srv.host}<br />
+                IP: {srv.ip}:{srv.port}<br />
+                Cost: {srv.cost}
+              </p>
+              <button className="btn btn-sm btn-secondary me-2" onClick={() => editServer(srv)}>
+                Edit
+              </button>
+              <button className="btn btn-sm btn-danger" onClick={() => deleteServer(srv.id)}>
+                Delete
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+

--- a/admin_frontend/src/Users.jsx
+++ b/admin_frontend/src/Users.jsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react'
+
+const apiUrl = import.meta.env.VITE_ADMIN_API_URL
+const apiKey = import.meta.env.VITE_ADMIN_API_KEY
+
+export default function Users() {
+  const [users, setUsers] = useState([])
+  const [error, setError] = useState('')
+
+  const fetchUsers = async () => {
+    try {
+      const res = await fetch(`${apiUrl}/api/users`, {
+        headers: { 'X-API-Key': apiKey },
+      })
+      if (!res.ok) throw new Error('Failed to fetch users')
+      setUsers(await res.json())
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  useEffect(() => {
+    fetchUsers()
+  }, [])
+
+  const topup = async (id) => {
+    const amount = prompt('Amount to top up')
+    if (!amount) return
+    await fetch(`${apiUrl}/api/users/${id}/topup`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': apiKey,
+      },
+      body: JSON.stringify({ amount: Number(amount) }),
+    })
+    fetchUsers()
+  }
+
+  const withdraw = async (id) => {
+    const amount = prompt('Amount to withdraw')
+    if (!amount) return
+    await fetch(`${apiUrl}/api/users/${id}/withdraw`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': apiKey,
+      },
+      body: JSON.stringify({ amount: Number(amount) }),
+    })
+    fetchUsers()
+  }
+
+  return (
+    <div className="container mt-3">
+      <h3>Users</h3>
+      {error && <div className="alert alert-danger">{error}</div>}
+      <div className="d-flex flex-wrap">
+        {users.map((u) => (
+          <div className="card m-2" style={{ minWidth: '18rem' }} key={u.id}>
+            <div className="card-body">
+              <h5 className="card-title">{u.username || 'User'} (ID {u.id})</h5>
+              <p className="card-text">
+                TG: {u.tg_id}<br />
+                Balance: {u.balance}
+              </p>
+              <button className="btn btn-sm btn-success me-2" onClick={() => topup(u.id)}>
+                Top up
+              </button>
+              <button className="btn btn-sm btn-warning" onClick={() => withdraw(u.id)}>
+                Withdraw
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- include Bootstrap in index.html
- overhaul Dashboard with navigation
- add server management with create/edit/delete
- add user list with top-up and withdraw actions
- add filterable config list

## Testing
- `npm run lint`
- `npm run build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68496ce21f7483249287817f87e28271