### PR TITLE
Fix duplicate authHeaders in admin frontend

### DIFF
--- a/admin_frontend/src/Configs.jsx
+++ b/admin_frontend/src/Configs.jsx
@@ -7,13 +7,6 @@ function authHeaders() {
   return token ? { Authorization: `Bearer ${token}` } : {}
 }
 
-function authHeaders() {
-  const token = localStorage.getItem('authToken')
-  if (token) return { Authorization: `Bearer ${token}` }
-  if (apiKey) return { 'X-API-Key': apiKey }
-  return {}
-}
-
 export default function Configs() {
   const [configs, setConfigs] = useState([])
   const [filters, setFilters] = useState({ server_id: '', owner_id: '', suspended: '' })

--- a/admin_frontend/src/Servers.jsx
+++ b/admin_frontend/src/Servers.jsx
@@ -7,13 +7,6 @@ function authHeaders() {
   return token ? { Authorization: `Bearer ${token}` } : {}
 }
 
-function authHeaders() {
-  const token = localStorage.getItem('authToken')
-  if (token) return { Authorization: `Bearer ${token}` }
-  if (apiKey) return { 'X-API-Key': apiKey }
-  return {}
-}
-
 export default function Servers() {
   const empty = { name: '', ip: '', port: 22, host: '', location: '', api_key: '', monthly_cost: 0 }
   const [servers, setServers] = useState([])

--- a/admin_frontend/src/Users.jsx
+++ b/admin_frontend/src/Users.jsx
@@ -7,13 +7,6 @@ function authHeaders() {
   return token ? { Authorization: `Bearer ${token}` } : {}
 }
 
-function authHeaders() {
-  const token = localStorage.getItem('authToken')
-  if (token) return { Authorization: `Bearer ${token}` }
-  if (apiKey) return { 'X-API-Key': apiKey }
-  return {}
-}
-
 export default function Users() {
   const [users, setUsers] = useState([])
   const [error, setError] = useState('')


### PR DESCRIPTION
## Summary
- remove duplicate `authHeaders` definitions in the admin frontend

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684baeb056d883249ff1552259fa9130