### PR TITLE
Use Decimal for user balance

### DIFF
--- a/admin/app.py
+++ b/admin/app.py
@@ -10,6 +10,7 @@ from .routers import servers as server_router
 from .routers import users as user_router
 from .routers import configs as config_router
 from . import exception_handlers
+from .dependencies import parse
 
 app = FastAPI()
 

--- a/admin/routers/auth.py
+++ b/admin/routers/auth.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException, status
 
-from core.config import settings
+from core.config import Settings
 from ..schemas import Login
 from .. import auth as auth_utils
 
@@ -9,9 +9,16 @@ router = APIRouter()
 
 @router.post("/login")
 async def login(data: Login):
+    settings = Settings()
     if not (settings.admin_username and settings.admin_password_hash):
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Login disabled")
-    if data.username != settings.admin_username or not auth_utils.verify_password(data.password):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid credentials")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Login disabled"
+        )
+    if data.username != settings.admin_username or not auth_utils.verify_password(
+        data.password
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Invalid credentials"
+        )
     token = auth_utils.generate_token()
     return {"token": token}

--- a/alembic/versions/7cdd648f17a9_balance_decimal.py
+++ b/alembic/versions/7cdd648f17a9_balance_decimal.py
@@ -1,0 +1,29 @@
+"""change balance to Numeric
+
+Revision ID: 7cdd648f17a9
+Revises: b73ad1f7657e
+Create Date: 2025-06-10 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "7cdd648f17a9"
+down_revision: Union[str, None] = "b73ad1f7657e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "user", "balance", type_=sa.Numeric(10, 2), existing_type=sa.Float()
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "user", "balance", type_=sa.Float(), existing_type=sa.Numeric(10, 2)
+    )

--- a/core/db/models/user.py
+++ b/core/db/models/user.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import BigInteger, DateTime, Float, String, func
+from decimal import Decimal
+
+from sqlalchemy import BigInteger, DateTime, Numeric, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from core.db import Base
@@ -17,7 +19,7 @@ class User(Base):
         DateTime, default=func.now(), server_default=func.now()
     )
 
-    balance: Mapped[float] = mapped_column(Float, default=0)
+    balance: Mapped[Decimal] = mapped_column(Numeric(10, 2), default=0)
 
     vpn_configs: Mapped[list["VPN_Config"]] = relationship(  # noqa F821 # type: ignore
         "VPN_Config",

--- a/core/services/models.py
+++ b/core/services/models.py
@@ -34,7 +34,7 @@ class User:
     tg_id: int
     username: str | None
     created: datetime
-    balance: float
+    balance: Decimal
 
     @classmethod
     def from_orm(cls, obj):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,11 +6,28 @@ from core.services.models import Server, User
 
 
 def test_serialize_dataclass_handles_datetime_and_decimal():
-    user = User(id=1, tg_id=2, username='name', created=datetime(2025, 1, 1, 12, 0), balance=1.5)
-    server = Server(id=1, name='srv', ip='1.1.1.1', port=22, host='host', monthly_cost=Decimal('3.5'), location='US', api_key='key')
+    user = User(
+        id=1,
+        tg_id=2,
+        username="name",
+        created=datetime(2025, 1, 1, 12, 0),
+        balance=Decimal("1.5"),
+    )
+    server = Server(
+        id=1,
+        name="srv",
+        ip="1.1.1.1",
+        port=22,
+        host="host",
+        monthly_cost=Decimal("3.5"),
+        location="US",
+        api_key="key",
+    )
 
     data_user = serialize_dataclass(user)
     data_server = serialize_dataclass(server)
 
-    assert data_user['created'] == user.created.isoformat()
-    assert isinstance(data_server['monthly_cost'], float) and data_server['monthly_cost'] == float(server.monthly_cost)
+    assert data_user["created"] == user.created.isoformat()
+    assert isinstance(data_server["monthly_cost"], float) and data_server[
+        "monthly_cost"
+    ] == float(server.monthly_cost)


### PR DESCRIPTION
## Summary
- store user balance in DB using Decimal
- update billing logic to use Decimal
- refresh user balance dataclass
- adjust authentication router to load settings dynamically
- add migration for decimal balances
- update test helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc95d70dc8324b13efd7424b40c3b