### PR TITLE
Add Redis token storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,4 @@ BILLING_INTERVAL=3600
 ADMIN_USERNAME=admin
 # bcrypt hash generated with: python -m bcrypt "your_password"
 ADMIN_PASSWORD_HASH=
+REDIS_URL=redis://redis:6379/0

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ from the PostgreSQL credentials, otherwise set it manually:
 - `BILLING_INTERVAL` – seconds between periodic charges
 - `ADMIN_USERNAME` – username for `/login`
 - `ADMIN_PASSWORD_HASH` – bcrypt hash of the login password
+- `REDIS_URL` – Redis connection string for token storage (default `redis://redis:6379/0`)
 
 A helper script `scripts/fernet_key_generator.py` can generate a new encryption key.
 
@@ -74,6 +75,7 @@ pytest
 
 - API keys of VPN servers are stored encrypted in the database using Fernet.
 - The admin API requires a login token obtained from the `/login` endpoint and should ideally be served over HTTPS.
+- Login tokens are stored in Redis with a 1 hour TTL.
 - Temporary configuration files created by the bot are placed in the system temp directory and removed immediately after sending.
 - Communication with VPN servers is performed over plain HTTP; ensure your environment is trusted or switch to HTTPS.
 

--- a/admin/dependencies.py
+++ b/admin/dependencies.py
@@ -4,17 +4,17 @@ from pydantic import BaseModel, ValidationError
 from . import auth
 
 
-def require_auth(request: Request) -> None:
+async def require_auth(request: Request) -> None:
     auth_header = request.headers.get("Authorization")
     if auth_header and auth_header.lower().startswith("bearer "):
         token = auth_header.split()[1]
-        if auth.token_valid(token):
+        if await auth.token_valid(token):
             return
     raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
 
 
-def auth_required(request: Request):
-    require_auth(request)
+async def auth_required(request: Request):
+    await require_auth(request)
 
 
 def parse(model: type[BaseModel], request: Request):

--- a/admin/routers/auth.py
+++ b/admin/routers/auth.py
@@ -20,5 +20,5 @@ async def login(data: Login):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Invalid credentials"
         )
-    token = auth_utils.generate_token()
+    token = await auth_utils.generate_token()
     return {"token": token}

--- a/core/config.py
+++ b/core/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     admin_username: str = ""
     admin_password_hash: str = ""
     telegram_pay_token: str = ""
+    redis_url: str = "redis://localhost:6379/0"
 
     class Config:
         env_file = ".env"

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -24,6 +24,10 @@ services:
       timeout: 5s
       retries: 10
 
+  redis:
+    image: redis:7
+    restart: unless-stopped
+
   migrations:
     image: andriyshkoy/vpn-migrations:latest
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,10 @@ services:
       timeout: 5s
       retries: 10
 
+  redis:
+    image: redis:7
+    restart: unless-stopped
+
   migrations:
     build:
       context: .

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,5 @@ uvicorn==0.29.0
 setuptools>=65.5
 asyncpg==0.29.0
 bcrypt==4.1.2
+redis==6.2.0
+fakeredis==2.30.1

--- a/tests/test_admin_api.py
+++ b/tests/test_admin_api.py
@@ -2,6 +2,7 @@ import importlib
 
 import bcrypt
 import pytest
+import fakeredis.aioredis
 from httpx import AsyncClient, ASGITransport
 
 from core.db.unit_of_work import uow
@@ -45,6 +46,8 @@ async def test_user_endpoints(monkeypatch, sessionmaker):
     core_config = importlib.reload(core_config)
     import admin.auth as admin_auth
     admin_auth = importlib.reload(admin_auth)
+    redis_client = fakeredis.aioredis.FakeRedis()
+    monkeypatch.setattr(admin_auth, "_get_redis", lambda: redis_client)
     import admin.app as admin_app
     admin_app = importlib.reload(admin_app)
 
@@ -91,6 +94,8 @@ async def test_config_list(monkeypatch, sessionmaker):
     core_config = importlib.reload(core_config)
     import admin.auth as admin_auth
     admin_auth = importlib.reload(admin_auth)
+    redis_client = fakeredis.aioredis.FakeRedis()
+    monkeypatch.setattr(admin_auth, "_get_redis", lambda: redis_client)
     import admin.app as admin_app
 
     admin_app = importlib.reload(admin_app)

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -2,6 +2,7 @@ import importlib
 
 import bcrypt
 import pytest
+import fakeredis.aioredis
 from httpx import ASGITransport, AsyncClient
 
 
@@ -16,6 +17,8 @@ async def test_login(monkeypatch, sessionmaker):
     core_config = importlib.reload(core_config)
     import admin.auth as admin_auth
     admin_auth = importlib.reload(admin_auth)
+    redis_client = fakeredis.aioredis.FakeRedis()
+    monkeypatch.setattr(admin_auth, "_get_redis", lambda: redis_client)
     import admin.app as admin_app
     admin_app = importlib.reload(admin_app)
 


### PR DESCRIPTION
## Summary
- use Redis instead of in-memory dict for admin tokens
- make authentication helpers async
- patch tests to use fakeredis
- expose `REDIS_URL` setting and Docker service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a6865bcb0832488e6b0c3dc55aeb2