### PR TITLE
Refactor billing daemon with rq scheduler

### DIFF
--- a/billing_daemon/billing_tasks.py
+++ b/billing_daemon/billing_tasks.py
@@ -1,5 +1,7 @@
 import asyncio
+from functools import lru_cache
 
+from aiohttp import ClientSession
 from aiogram import Bot
 
 from core.config import settings
@@ -10,22 +12,25 @@ from core.services import BillingService
 LOW_BALANCE_THRESHOLD = 10
 
 
+@lru_cache()
+def _get_bot() -> Bot:
+    """Return a singleton Bot instance with shared HTTP session."""
+    session = ClientSession()
+    return Bot(token=settings.bot_token, session=session)
+
+
 async def _charge_all_and_notify_async() -> None:
     billing = BillingService(uow, per_config_cost=settings.per_config_cost)
-    charged_users = await billing.charge_all()
-    users = charged_users
+    users = await billing.charge_all()
 
-    bot = Bot(token=settings.bot_token)
-    try:
-        for user in users:
-            if user.balance < LOW_BALANCE_THRESHOLD:
-                text = (
-                    f"\u26a0\ufe0f Ваш баланс {user.balance} "
-                    f"меньше {LOW_BALANCE_THRESHOLD}. Пополните счёт."
-                )
-                await bot.send_message(user.tg_id, text)
-    finally:
-        await bot.session.close()
+    bot = _get_bot()
+    for user in users:
+        if user.balance < LOW_BALANCE_THRESHOLD:
+            text = (
+                f"\u26a0\ufe0f Ваш баланс {user.balance} "
+                f"меньше {LOW_BALANCE_THRESHOLD}. Пополните счёт."
+            )
+            await bot.send_message(user.tg_id, text)
 
 
 def charge_all_and_notify() -> None:

--- a/billing_daemon/main.py
+++ b/billing_daemon/main.py
@@ -1,26 +1,15 @@
-import time
-from threading import Thread
+from multiprocessing import Process
 
-
-from redis import Redis
-from rq import Queue
 
 from core.config import settings
 
-from .billing_tasks import charge_all_and_notify
 from .rq_worker import run_worker
+from .scheduler import bootstrap_schedule
 
 
-
-
-def _scheduler() -> None:
-    redis_conn = Redis.from_url(settings.redis_url)
-    queue = Queue("billing", connection=redis_conn)
-    while True:
-        queue.enqueue(charge_all_and_notify)
-        time.sleep(settings.billing_interval)
 
 
 if __name__ == "__main__":
-    Thread(target=run_worker, daemon=True).start()
-    _scheduler()
+    worker = Process(target=run_worker, daemon=True)
+    worker.start()
+    bootstrap_schedule()

--- a/billing_daemon/rq_worker.py
+++ b/billing_daemon/rq_worker.py
@@ -1,14 +1,14 @@
 from redis import Redis
-from rq import Connection, Queue, Worker
+from rq import Queue, Worker
 
 from core.config import settings
 
 
 def run_worker() -> None:
     redis_conn = Redis.from_url(settings.redis_url)
-    with Connection(redis_conn):
-        worker = Worker([Queue("billing")])
-        worker.work()
+    queue = Queue("billing", connection=redis_conn, default_timeout=3600)
+    worker = Worker([queue], connection=redis_conn)
+    worker.work(logging_level="INFO")
 
 
 if __name__ == "__main__":

--- a/billing_daemon/scheduler.py
+++ b/billing_daemon/scheduler.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from redis import Redis
+from rq import Queue
+from rq_scheduler import Scheduler
+
+from core.config import settings
+from .billing_tasks import charge_all_and_notify
+
+
+def bootstrap_schedule() -> None:
+    """Initialize RQ scheduler for periodic billing job."""
+    redis_conn = Redis.from_url(settings.redis_url)
+    queue = Queue("billing", connection=redis_conn, default_timeout=3600)
+    scheduler = Scheduler(queue=queue, connection=redis_conn)
+
+    if scheduler.get_job("charge_all_job") is None:
+        scheduler.schedule(
+            scheduled_time=datetime.utcnow(),
+            func=charge_all_and_notify,
+            interval=settings.billing_interval,
+            id="charge_all_job",
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,4 @@ bcrypt==4.1.2
 redis==6.2.0
 fakeredis==2.30.1
 rq==2.4.0
+rq-scheduler==0.13.1


### PR DESCRIPTION
## Summary
- ensure single Bot session in billing daemon
- switch worker & scheduler logic to support rq >= 2
- add rq-scheduler based scheduler
- launch worker as separate process
- include rq-scheduler in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac0fd39208324958152ec366a861e