### PR TITLE
Implement Redis notification queue

### DIFF
--- a/core/services/__init__.py
+++ b/core/services/__init__.py
@@ -2,6 +2,7 @@ from .api_gateway import APIGateway
 from .billing import BillingService
 from .config import ConfigService
 from .models import Config, Server, User
+from .notifications import Notification, NotificationService
 from .payments import CryptoPaymentService, TelegramPayService
 from .server import ServerService
 from .user import UserService
@@ -14,6 +15,8 @@ __all__ = [
     "ConfigService",
     "TelegramPayService",
     "CryptoPaymentService",
+    "NotificationService",
+    "Notification",
     "Server",
     "User",
     "Config",

--- a/core/services/models.py
+++ b/core/services/models.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from decimal import Decimal
 
 
-@dataclass
+@dataclass(frozen=True)
 class Server:
     id: int
     name: str
@@ -28,7 +28,7 @@ class Server:
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class User:
     id: int
     tg_id: int
@@ -47,7 +47,7 @@ class User:
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class Config:
     id: int
     name: str

--- a/core/services/notifications.py
+++ b/core/services/notifications.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Sequence
+
+import redis.asyncio as redis
+
+from core.config import settings
+
+
+@dataclass
+class Notification:
+    """Simple representation of a pending Telegram message."""
+
+    chat_id: int
+    text: str
+
+
+class NotificationService:
+    """Redis-backed queue for notifications."""
+
+    def __init__(
+        self,
+        redis_client: redis.Redis | None = None,
+        *,
+        key: str = "notifications",
+    ) -> None:
+        self._redis = redis_client or redis.from_url(
+            settings.redis_url, decode_responses=True
+        )
+        self._key = key
+
+    async def enqueue(self, chat_id: int, text: str) -> None:
+        """Add a new notification to the queue."""
+        data = json.dumps({"chat_id": chat_id, "text": text})
+        await self._redis.rpush(self._key, data)
+
+    async def get_pending(self) -> Sequence[Notification]:
+        """Return and remove all queued notifications."""
+        raw = await self._redis.lrange(self._key, 0, -1)
+        if raw:
+            await self._redis.delete(self._key)
+        return [
+            Notification(chat_id=int(item["chat_id"]), text=item["text"])
+            for item in map(json.loads, raw)
+        ]

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,20 @@
+import fakeredis.aioredis
+import pytest
+
+from core.services.notifications import Notification, NotificationService
+
+
+@pytest.mark.asyncio
+async def test_notification_queue(monkeypatch):
+    redis_client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    service = NotificationService(redis_client)
+
+    await service.enqueue(1, "hello")
+    await service.enqueue(2, "bye")
+
+    messages = await service.get_pending()
+    assert messages == [
+        Notification(chat_id=1, text="hello"),
+        Notification(chat_id=2, text="bye"),
+    ]
+    assert await redis_client.llen("notifications") == 0


### PR DESCRIPTION
## Summary
- add `NotificationService` for storing messages in Redis
- enqueue notifications in billing daemon rather than sending directly
- expose new service from `core.services`
- update billing task tests for new queue
- add unit test for `NotificationService`
- adjust billing service return type and notification logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af077d4748324b4d4866a557149f9