### PR TITLE
Implement Telegram notification listener

### DIFF
--- a/bot/notifications.py
+++ b/bot/notifications.py
@@ -1,0 +1,32 @@
+"""Telegram notification listener for the bot."""
+
+from __future__ import annotations
+
+import asyncio
+from aiogram import Bot
+
+from core.services.notifications import NotificationService
+
+
+async def send_pending_notifications(bot: Bot, service: NotificationService) -> None:
+    """Send all queued notifications using the provided bot."""
+    pending = await service.get_pending()
+    for note in pending:
+        try:
+            await bot.send_message(note.chat_id, note.text)
+        except Exception:
+            # Ignore delivery errors
+            pass
+
+
+async def notifications_listener(
+    bot: Bot,
+    *,
+    poll_interval: float = 5.0,
+    service: NotificationService | None = None,
+) -> None:
+    """Continuously poll Redis for notifications and send them."""
+    service = service or NotificationService()
+    while True:
+        await send_pending_notifications(bot, service)
+        await asyncio.sleep(poll_interval)

--- a/tests/test_bot_notifications.py
+++ b/tests/test_bot_notifications.py
@@ -1,0 +1,28 @@
+import fakeredis.aioredis
+import pytest
+
+from bot.notifications import send_pending_notifications
+from core.services.notifications import NotificationService
+
+
+class DummyBot:
+    def __init__(self):
+        self.sent = []
+
+    async def send_message(self, chat_id, text):
+        self.sent.append((chat_id, text))
+
+
+@pytest.mark.asyncio
+async def test_send_pending_notifications():
+    redis_client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    service = NotificationService(redis_client)
+
+    await service.enqueue(1, "hello")
+    await service.enqueue(2, "bye")
+
+    bot = DummyBot()
+    await send_pending_notifications(bot, service)
+
+    assert bot.sent == [(1, "hello"), (2, "bye")]
+    assert await redis_client.llen("notifications") == 0


### PR DESCRIPTION
## Summary
- support background notification dispatch for telegram bot
- expose listener to enqueue messages
- unit test notification dispatch logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af98074148324b2fd342e85b11338