### PR TITLE
Update README and env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,7 @@ POSTGRES_DB=vpn
 POSTGRES_USER=vpn
 POSTGRES_PASSWORD=vpn
 
-# Application settings
-# Used only when running without Docker Compose; compose derives it automatically
+# Application settings (used by Docker Compose)
 DATABASE_URL=postgresql+asyncpg://vpn:vpn@db:5432/vpn
 ENCRYPTION_KEY=change_me
 BOT_TOKEN=change_me


### PR DESCRIPTION
## Summary
- refresh the README with accurate setup instructions
- describe the admin frontend and Docker-only deployment
- update `.env.example` to remove non-Docker notes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c5a6990ac832499e8497fc611054c