### PR TITLE
Keep canary preflight smoke stdin attached

### DIFF
--- a/deploy/production_canary.sh
+++ b/deploy/production_canary.sh
@@ -486,7 +486,7 @@ log "testing exact bot image against restored data and live Manager mTLS"
 PREFLIGHT_MANAGER_LOG="$BACKUP_DIR/preflight-manager-smoke.log"
 : > "$PREFLIGHT_MANAGER_LOG"
 chmod 0600 "$PREFLIGHT_MANAGER_LOG"
-if ! docker run --rm \
+if ! docker run --rm -i \
     --network "$PREFLIGHT_NETWORK" \
     --read-only \
     --cap-drop ALL \
@@ -511,7 +511,7 @@ log "testing production Telegram identity before live migration"
 PREFLIGHT_TELEGRAM_LOG="$BACKUP_DIR/preflight-telegram-smoke.log"
 : > "$PREFLIGHT_TELEGRAM_LOG"
 chmod 0600 "$PREFLIGHT_TELEGRAM_LOG"
-if ! docker run --rm \
+if ! docker run --rm -i \
     --network "$PREFLIGHT_NETWORK" \
     --read-only \
     --cap-drop ALL \

--- a/tests/test_production_canary_cleanup.sh
+++ b/tests/test_production_canary_cleanup.sh
@@ -10,6 +10,13 @@ trap 'rm -f "$EVENTS_FILE"' EXIT
 # shellcheck source=../deploy/production_canary.sh
 source "$REPO_ROOT/deploy/production_canary.sh"
 
+interactive_smoke_count="$(
+    grep -Fc \
+        'if ! docker run --rm -i' \
+        "$REPO_ROOT/deploy/production_canary.sh"
+)"
+[[ "$interactive_smoke_count" == "2" ]]
+
 status=0
 if (
     cleanup_preflight() {


### PR DESCRIPTION
## Fix

`docker run` does not attach stdin unless `-i` is set. The two pre-migration smoke containers invoked `python -` without it, so they exited successfully without executing the reviewed Manager/Telegram scripts.

This patch:

- attaches stdin for both pre-migration smoke containers;
- adds a regression assertion requiring both interactive invocations;
- leaves the already-running production canary untouched.

The post-migration Manager and Telegram smokes in release `7718843` did execute and pass; this fixes the future pre-migration gate.

## Verification

- cleanup/interactive smoke regression passes;
- Bash syntax, ShellCheck, actionlint, and diff checks pass.
