### PR TITLE
Harden active production scheduling and admin bind

### DIFF
--- a/billing_daemon/scheduler.py
+++ b/billing_daemon/scheduler.py
@@ -14,6 +14,7 @@ from .billing_tasks import (
 )
 
 REFERRAL_RECONCILE_INTERVAL = 300
+SCHEDULER_POLL_INTERVAL = 30
 
 
 def main() -> None:
@@ -21,7 +22,7 @@ def main() -> None:
     scheduler = Scheduler(
         queue=Queue("billing", connection=redis_conn),
         connection=redis_conn,
-        interval=settings.billing_interval,
+        interval=SCHEDULER_POLL_INTERVAL,
     )
 
     if "charge_all_job" not in scheduler:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -283,7 +283,9 @@ services:
     depends_on:
       - admin_frontend
     ports:
-      - "14081:80"
+      # The host Nginx terminates TLS for admin.vpn.andriyshkoy.ru. Keep the
+      # application proxy off the public interfaces so :14081 cannot bypass it.
+      - "127.0.0.1:14081:80"
     networks: [edge]
     restart: unless-stopped
 

--- a/docs/production-rollout.md
+++ b/docs/production-rollout.md
@@ -119,6 +119,11 @@ docker compose --env-file .env --env-file release.env \
 
 Reject any backend/UI image ending in `:latest` or `:unreleased`.
 
+The production admin proxy binds only to `127.0.0.1:14081`. The host Nginx
+must terminate TLS for `admin.vpn.andriyshkoy.ru` and proxy to that loopback
+address. Do not publish port `14081` on a public interface: doing so would
+bypass the host TLS boundary.
+
 ## Staged startup
 
 Start only the data services and prove the mounted database identity:

--- a/tests/test_billing_tasks.py
+++ b/tests/test_billing_tasks.py
@@ -164,9 +164,11 @@ def test_scheduler_registers_referral_reconciliation(monkeypatch):
     import billing_daemon.scheduler as scheduler_module
 
     scheduled = []
+    scheduler_options = []
 
     class DummyScheduler:
         def __init__(self, **kwargs):
+            scheduler_options.append(kwargs)
             self.jobs = {}
 
         def __contains__(self, job_id):
@@ -182,8 +184,15 @@ def test_scheduler_registers_referral_reconciliation(monkeypatch):
     monkeypatch.setattr(scheduler_module.Redis, "from_url", lambda url: object())
     monkeypatch.setattr(scheduler_module, "Queue", lambda *args, **kwargs: object())
     monkeypatch.setattr(scheduler_module, "Scheduler", DummyScheduler)
+    monkeypatch.setattr(scheduler_module.settings, "billing_interval", 7200)
 
     scheduler_module.main()
+
+    assert scheduler_options[0]["interval"] == 30
+
+    charge_job = next(job for job in scheduled if job["id"] == "charge_all_job")
+    assert charge_job["func"] is scheduler_module.charge_all_and_notify
+    assert charge_job["interval"] == 7200
 
     referral_job = next(
         job for job in scheduled if job["id"] == "reconcile_referral_rewards_job"

--- a/tests/test_observability_config.py
+++ b/tests/test_observability_config.py
@@ -101,6 +101,10 @@ def test_production_release_is_explicit_segmented_and_volume_safe():
         assert "unreleased" not in service
         assert f"image: ${{{image_variable}:?{image_variable} is required}}" in service
     assert "env_file:" not in _service_block(compose, "admin_frontend")
+    nginx = _service_block(compose, "nginx")
+    assert '      - "127.0.0.1:14081:80"' in nginx
+    assert '      - "14081:80"' not in nginx
+    assert '      - "0.0.0.0:14081:80"' not in nginx
 
     release_policy = _top_level_block(compose, "x-release-policy-environment")
     for flag in (


### PR DESCRIPTION
## Summary

- poll RQ Scheduler every 30 seconds without changing the configured financial billing interval
- bind the production admin proxy only to `127.0.0.1:14081` so direct HTTP cannot bypass host TLS
- document and test both production invariants

## Context

During guarded activation, the existing scheduler was found to use `BILLING_INTERVAL=3600` as its polling sleep. Jobs remained financially hourly, but 30/300-second reconciliation jobs and even the first hourly boundary could be observed late. The admin profile also exposed `:14081` on all interfaces.

Production has already been activated with the loopback bind as a reviewed runtime hotfix. The scheduler is running safely with no historical catch-up; this code fix takes effect with the next billing image release.

## Verification

- focused backend/config suite: 13 passed
- Black and isort clean
- production Compose render and loopback port assertion passed
- actionlint and diff checks passed
