### PR TITLE
Improve tariff copy and split balance history

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ stored independently from balance-based suspension. Installation help is split
 by platform and points to official OpenVPN clients. The referral screen shows
 only the account owner's opaque invite link, aggregate two-level counts, and
 earned totals; it never exposes another user's Telegram identity or individual
-deposit. The balance screen exposes a paginated private ledger history with the
-amount, reason, timestamp, and resulting balance for every recorded movement.
+deposit. The balance screen exposes separate paginated views for credits and
+debits, with the amount, reason, timestamp, and resulting balance for every
+recorded movement.
 See [the referral accounting guide](docs/referrals.md) for policy, backfill,
 and manual-refund boundaries.
 

--- a/bot/handlers/balance_history.py
+++ b/bot/handlers/balance_history.py
@@ -30,15 +30,27 @@ _KIND_LABELS = {
 accounting_service = AccountingService(uow)
 
 
-def render_balance_history(page: BalanceHistoryPage) -> str:
+def render_balance_history(
+    page: BalanceHistoryPage,
+    *,
+    direction: str | None = None,
+) -> str:
+    title = {
+        "credit": "➕ <b>Пополнения и начисления</b>",
+        "debit": "➖ <b>Списания</b>",
+    }.get(direction, "📒 <b>История баланса</b>")
     if not page.items:
-        return (
-            "📒 <b>История баланса</b>\n\n"
+        empty_text = {
+            "credit": "Пополнений и начислений пока нет.",
+            "debit": "Списаний пока нет.",
+        }.get(
+            direction,
             "Операций пока нет. После первого пополнения или списания они "
-            "появятся здесь."
+            "появятся здесь.",
         )
+        return f"{title}\n\n{empty_text}"
 
-    lines = ["📒 <b>История баланса</b>", ""]
+    lines = [title, ""]
     for item in page.items:
         created_at = item.created_at
         if created_at.tzinfo is None:
@@ -58,7 +70,11 @@ def render_balance_history(page: BalanceHistoryPage) -> str:
 
     first = page.offset + 1
     last = page.offset + len(page.items)
-    lines.append(f"Операции {first}–{last} из {page.total}")
+    page_label = {
+        "credit": "Пополнения и начисления",
+        "debit": "Списания",
+    }.get(direction, "Операции")
+    lines.append(f"{page_label} {first}–{last} из {page.total}")
     return "\n".join(lines)
 
 
@@ -68,6 +84,7 @@ async def _history_for_telegram_user(
     *,
     offset: int,
     snapshot_id: int | None = None,
+    direction: str | None = None,
 ) -> BalanceHistoryPage | None:
     user = await get_or_create_user(tg_id, username)
     if user is None:
@@ -77,6 +94,7 @@ async def _history_for_telegram_user(
         limit=HISTORY_PAGE_SIZE,
         offset=offset,
         snapshot_id=snapshot_id,
+        direction=direction,
     )
 
 
@@ -95,6 +113,7 @@ async def cmd_balance_history(message: Message) -> None:
             limit=page.limit,
             total=page.total,
             snapshot_id=page.snapshot_id,
+            direction=None,
         ),
     )
 
@@ -104,6 +123,9 @@ async def balance_history_callback(callback: CallbackQuery) -> None:
     raw_cursor = callback.data.partition(":")[2]
     try:
         cursor_parts = raw_cursor.split(":")
+        direction = None
+        if cursor_parts[0] in ("credit", "debit"):
+            direction = cursor_parts.pop(0)
         if len(cursor_parts) == 1:
             snapshot_id = None
             offset = int(cursor_parts[0])
@@ -128,18 +150,20 @@ async def balance_history_callback(callback: CallbackQuery) -> None:
         callback.from_user.username,
         offset=offset,
         snapshot_id=snapshot_id,
+        direction=direction,
     )
     if page is None:
         await safe_callback_answer(callback)
         return
     await safe_edit_text(
         callback.message,
-        render_balance_history(page),
+        render_balance_history(page, direction=direction),
         reply_markup=balance_history_keyboard(
             offset=page.offset,
             limit=page.limit,
             total=page.total,
             snapshot_id=page.snapshot_id,
+            direction=direction,
         ),
     )
     await safe_callback_answer(callback)

--- a/bot/handlers/configs.py
+++ b/bot/handlers/configs.py
@@ -24,8 +24,9 @@ from core.exceptions import APIConnectionError, InsufficientBalanceError, Servic
 from ..keyboards import cancel_keyboard, main_menu_keyboard
 from ..states import CreateConfig, RenameConfig
 from ..ui import (
-    format_billing_interval,
+    estimate_monthly_cost,
     format_money,
+    format_whole_money,
     safe_callback_answer,
     safe_document_filename,
     safe_edit_text,
@@ -193,9 +194,10 @@ async def _begin_create_config(
         "➕ <b>Новая конфигурация</b>\n\n"
         "Выберите ближайший сервер.\n\n"
         f"Создание — <b>{format_money(settings.config_creation_cost)} ₽</b>.\n"
-        f"Обслуживание — <b>{format_money(settings.per_config_cost)} ₽</b> "
-        f"{format_billing_interval(settings.billing_interval)} за каждую "
-        "конфигурацию.",
+        "Стоимость VPN — "
+        f"<b>около {format_whole_money(estimate_monthly_cost(settings.per_config_cost, settings.billing_interval))} ₽ "
+        "в месяц</b> за каждую конфигурацию. Сумма списывается с баланса "
+        "постепенно — небольшими частями в течение месяца.",
         reply_markup=InlineKeyboardMarkup(inline_keyboard=buttons),
     )
     await state.set_state(CreateConfig.choosing_server)

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -54,9 +54,13 @@ def balance_actions_keyboard() -> InlineKeyboardMarkup:
         inline_keyboard=[
             [
                 InlineKeyboardButton(
-                    text="📒 История операций",
-                    callback_data="balance_history:0",
-                )
+                    text="➕ Пополнения",
+                    callback_data="balance_history:credit:0",
+                ),
+                InlineKeyboardButton(
+                    text="➖ Списания",
+                    callback_data="balance_history:debit:0",
+                ),
             ]
         ]
     )
@@ -68,28 +72,45 @@ def balance_history_keyboard(
     limit: int,
     total: int,
     snapshot_id: int,
+    direction: str | None = None,
 ) -> InlineKeyboardMarkup:
     """Bounded pagination for a user's private ledger history."""
+
+    callback_prefix = "balance_history"
+    if direction is not None:
+        callback_prefix += f":{direction}"
 
     navigation: list[InlineKeyboardButton] = []
     if offset > 0:
         navigation.append(
             InlineKeyboardButton(
                 text="⬅️ Новее",
-                callback_data=(
-                    f"balance_history:{snapshot_id}:{max(0, offset - limit)}"
-                ),
+                callback_data=f"{callback_prefix}:{snapshot_id}:"
+                f"{max(0, offset - limit)}",
             )
         )
     if offset + limit < total:
         navigation.append(
             InlineKeyboardButton(
                 text="Старее ➡️",
-                callback_data=f"balance_history:{snapshot_id}:{offset + limit}",
+                callback_data=f"{callback_prefix}:{snapshot_id}:{offset + limit}",
             )
         )
 
-    rows = [navigation] if navigation else []
+    rows = [
+        [
+            InlineKeyboardButton(
+                text=("✅" if direction == "credit" else "➕") + " Пополнения",
+                callback_data="balance_history:credit:0",
+            ),
+            InlineKeyboardButton(
+                text=("✅" if direction == "debit" else "➖") + " Списания",
+                callback_data="balance_history:debit:0",
+            ),
+        ]
+    ]
+    if navigation:
+        rows.append(navigation)
     rows.append(
         [InlineKeyboardButton(text="💰 К балансу", callback_data="balance_summary")]
     )
@@ -102,9 +123,13 @@ def referral_program_keyboard(share_url: str) -> InlineKeyboardMarkup:
             [InlineKeyboardButton(text="📨 Поделиться ссылкой", url=share_url)],
             [
                 InlineKeyboardButton(
-                    text="📒 История баланса",
-                    callback_data="balance_history:0",
-                )
+                    text="➕ Пополнения",
+                    callback_data="balance_history:credit:0",
+                ),
+                InlineKeyboardButton(
+                    text="➖ Списания",
+                    callback_data="balance_history:debit:0",
+                ),
             ],
         ]
     )

--- a/bot/ui.py
+++ b/bot/ui.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 from typing import Any
 
 from aiogram.exceptions import TelegramBadRequest
@@ -12,19 +12,22 @@ def format_money(value: Decimal | int | str) -> str:
     return f"{amount:,.2f}".replace(",", " ").replace(".", ",")
 
 
-def format_billing_interval(seconds: int) -> str:
-    if seconds == 60:
-        return "раз в минуту"
-    if seconds % 86_400 == 0:
-        days = seconds // 86_400
-        return "раз в день" if days == 1 else f"раз в {days} дн."
-    if seconds % 3_600 == 0:
-        hours = seconds // 3_600
-        return "раз в час" if hours == 1 else f"раз в {hours} ч."
-    if seconds % 60 == 0:
-        minutes = seconds // 60
-        return f"раз в {minutes} мин."
-    return f"раз в {seconds} сек."
+def format_whole_money(value: Decimal | int | str) -> str:
+    amount = Decimal(str(value))
+    return f"{amount:,.0f}".replace(",", " ")
+
+
+def estimate_monthly_cost(
+    per_period_cost: Decimal | int | str,
+    billing_interval_seconds: int,
+) -> Decimal:
+    """Return a user-facing whole-ruble estimate for a 30-day month."""
+
+    periods_per_month = Decimal(30 * 24 * 60 * 60) / Decimal(billing_interval_seconds)
+    return (Decimal(str(per_period_cost)) * periods_per_month).quantize(
+        Decimal("1"),
+        rounding=ROUND_HALF_UP,
+    )
 
 
 def safe_document_filename(value: str | None) -> str:

--- a/core/services/accounting.py
+++ b/core/services/accounting.py
@@ -52,6 +52,7 @@ class AccountingService:
         limit: int = 8,
         offset: int = 0,
         snapshot_id: int | None = None,
+        direction: str | None = None,
     ) -> BalanceHistoryPage:
         if (
             isinstance(limit, bool)
@@ -71,6 +72,8 @@ class AccountingService:
             or not 0 <= snapshot_id <= 9_223_372_036_854_775_807
         ):
             raise InvalidOperationError("Invalid balance history snapshot")
+        if direction not in (None, "credit", "debit"):
+            raise InvalidOperationError("Invalid balance history direction")
 
         async with self._uow() as repos:
             session = repos["users"].session
@@ -90,6 +93,10 @@ class AccountingService:
                 LedgerEntry.user_id == user_id,
                 LedgerEntry.id <= snapshot_id,
             )
+            if direction == "credit":
+                history_scope += (LedgerEntry.amount > 0,)
+            elif direction == "debit":
+                history_scope += (LedgerEntry.amount < 0,)
 
             total = int(
                 await session.scalar(

--- a/tests/test_accounting.py
+++ b/tests/test_accounting.py
@@ -69,3 +69,49 @@ async def test_balance_history_validates_owner_and_pagination(sessionmaker):
         await accounting.list_balance_history(1, offset=-1)
     with pytest.raises(InvalidOperationError):
         await accounting.list_balance_history(1, offset=1_000_001)
+    with pytest.raises(InvalidOperationError):
+        await accounting.list_balance_history(1, direction="all")
+
+
+@pytest.mark.asyncio
+async def test_balance_history_filters_credits_and_debits_with_stable_snapshot(
+    sessionmaker,
+):
+    users = UserService(uow)
+    billing = BillingService(uow, per_config_cost="1.00")
+    accounting = AccountingService(uow)
+    user = await users.register(91_003, balance="10.00")
+
+    await billing.top_up(user.id, "5.00", idempotency_key="filter:credit:1")
+    await billing.withdraw(user.id, "2.00", idempotency_key="filter:debit:1")
+
+    credits = await accounting.list_balance_history(
+        user.id,
+        direction="credit",
+        limit=1,
+    )
+    debits = await accounting.list_balance_history(user.id, direction="debit")
+
+    assert credits.total == 2
+    assert [item.amount for item in credits.items] == [Decimal("5.00")]
+    assert debits.total == 1
+    assert [item.amount for item in debits.items] == [Decimal("-2.00")]
+
+    await billing.top_up(user.id, "3.00", idempotency_key="filter:credit:2")
+    stable_second_page = await accounting.list_balance_history(
+        user.id,
+        direction="credit",
+        limit=1,
+        offset=1,
+        snapshot_id=credits.snapshot_id,
+    )
+    refreshed = await accounting.list_balance_history(user.id, direction="credit")
+
+    assert stable_second_page.total == 2
+    assert [item.amount for item in stable_second_page.items] == [Decimal("10.00")]
+    assert refreshed.total == 3
+    assert [item.amount for item in refreshed.items] == [
+        Decimal("3.00"),
+        Decimal("5.00"),
+        Decimal("10.00"),
+    ]

--- a/tests/test_balance_history_ui.py
+++ b/tests/test_balance_history_ui.py
@@ -1,8 +1,12 @@
 from datetime import datetime, timezone
 from decimal import Decimal
+from types import SimpleNamespace
 
+import pytest
+
+from bot.handlers import balance_history as balance_history_handler
 from bot.handlers.balance_history import render_balance_history
-from bot.keyboards import balance_history_keyboard
+from bot.keyboards import balance_actions_keyboard, balance_history_keyboard
 from core.services import BalanceHistoryItem, BalanceHistoryPage
 
 
@@ -53,17 +57,187 @@ def test_balance_history_renders_referral_and_charge_details_without_metadata():
 
 
 def test_balance_history_keyboard_bounds_pagination():
-    first = balance_history_keyboard(offset=0, limit=8, total=20, snapshot_id=42)
-    middle = balance_history_keyboard(offset=8, limit=8, total=20, snapshot_id=42)
-    last = balance_history_keyboard(offset=16, limit=8, total=20, snapshot_id=42)
+    first = balance_history_keyboard(
+        offset=0,
+        limit=8,
+        total=20,
+        snapshot_id=42,
+        direction="credit",
+    )
+    middle = balance_history_keyboard(
+        offset=8,
+        limit=8,
+        total=20,
+        snapshot_id=42,
+        direction="credit",
+    )
+    last = balance_history_keyboard(
+        offset=16,
+        limit=8,
+        total=20,
+        snapshot_id=42,
+        direction="credit",
+    )
 
-    assert [button.callback_data for button in first.inline_keyboard[0]] == [
-        "balance_history:42:8"
+    assert [button.callback_data for button in first.inline_keyboard[1]] == [
+        "balance_history:credit:42:8"
     ]
-    assert [button.callback_data for button in middle.inline_keyboard[0]] == [
-        "balance_history:42:0",
-        "balance_history:42:16",
+    assert [button.callback_data for button in middle.inline_keyboard[1]] == [
+        "balance_history:credit:42:0",
+        "balance_history:credit:42:16",
     ]
-    assert [button.callback_data for button in last.inline_keyboard[0]] == [
-        "balance_history:42:8"
+    assert [button.callback_data for button in last.inline_keyboard[1]] == [
+        "balance_history:credit:42:8"
     ]
+
+
+def test_balance_history_is_split_into_credit_and_debit_views():
+    actions = balance_actions_keyboard()
+    callbacks = [button.callback_data for button in actions.inline_keyboard[0]]
+    assert callbacks == [
+        "balance_history:credit:0",
+        "balance_history:debit:0",
+    ]
+
+    credit_page = BalanceHistoryPage(
+        items=(
+            _item(
+                item_id=1,
+                amount="25.00",
+                kind="provider_payment",
+                balance_after="25.00",
+            ),
+        ),
+        total=1,
+        limit=8,
+        offset=0,
+        snapshot_id=42,
+    )
+    debit_page = BalanceHistoryPage(
+        items=(),
+        total=0,
+        limit=8,
+        offset=0,
+        snapshot_id=42,
+    )
+
+    credit_text = render_balance_history(
+        credit_page,
+        direction="credit",
+    )
+    assert "<b>Пополнения и начисления</b>" in credit_text
+    assert "Пополнения и начисления 1–1 из 1" in credit_text
+    assert "Списаний пока нет" in render_balance_history(
+        debit_page,
+        direction="debit",
+    )
+
+
+class _CallbackMessage:
+    def __init__(self):
+        self.edits = []
+
+    async def edit_text(self, text, **kwargs):
+        self.edits.append((text, kwargs))
+
+
+class _Callback:
+    def __init__(self, data: str):
+        self.data = data
+        self.from_user = SimpleNamespace(id=101, username="alice")
+        self.message = _CallbackMessage()
+        self.answers = []
+
+    async def answer(self, *args, **kwargs):
+        self.answers.append((args, kwargs))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "data",
+    [
+        "balance_history:refund:0",
+        "balance_history:credit:not-a-snapshot:0",
+        "balance_history:debit:-1",
+        "balance_history:credit:1:2:3",
+    ],
+)
+async def test_balance_history_callback_rejects_unknown_direction_and_bad_cursor(data):
+    callback = _Callback(data)
+
+    await balance_history_handler.balance_history_callback(callback)
+
+    assert callback.answers == [(("Не удалось открыть эту страницу.",), {})]
+    assert callback.message.edits == []
+
+
+@pytest.mark.asyncio
+async def test_balance_history_callback_passes_direction_and_snapshot(monkeypatch):
+    observed = {}
+    page = BalanceHistoryPage(
+        items=(),
+        total=0,
+        limit=8,
+        offset=8,
+        snapshot_id=42,
+    )
+
+    async def history(tg_id, username, **kwargs):
+        observed.update(tg_id=tg_id, username=username, **kwargs)
+        return page
+
+    monkeypatch.setattr(
+        balance_history_handler,
+        "_history_for_telegram_user",
+        history,
+    )
+    callback = _Callback("balance_history:debit:42:8")
+
+    await balance_history_handler.balance_history_callback(callback)
+
+    assert observed == {
+        "tg_id": 101,
+        "username": "alice",
+        "offset": 8,
+        "snapshot_id": 42,
+        "direction": "debit",
+    }
+    text, kwargs = callback.message.edits[-1]
+    assert "<b>Списания</b>" in text
+    assert kwargs["reply_markup"].inline_keyboard[0][1].text.startswith("✅")
+    assert callback.answers == [((), {})]
+
+
+@pytest.mark.asyncio
+async def test_balance_history_callback_keeps_legacy_cursor_compatible(monkeypatch):
+    observed = {}
+    page = BalanceHistoryPage(
+        items=(),
+        total=0,
+        limit=8,
+        offset=8,
+        snapshot_id=42,
+    )
+
+    async def history(tg_id, username, **kwargs):
+        observed.update(tg_id=tg_id, username=username, **kwargs)
+        return page
+
+    monkeypatch.setattr(
+        balance_history_handler,
+        "_history_for_telegram_user",
+        history,
+    )
+    callback = _Callback("balance_history:42:8")
+
+    await balance_history_handler.balance_history_callback(callback)
+
+    assert observed == {
+        "tg_id": 101,
+        "username": "alice",
+        "offset": 8,
+        "snapshot_id": 42,
+        "direction": None,
+    }
+    assert "<b>История баланса</b>" in callback.message.edits[-1][0]
+    assert callback.answers == [((), {})]

--- a/tests/test_bot_ui.py
+++ b/tests/test_bot_ui.py
@@ -156,6 +156,47 @@ async def test_config_fsm_gives_hints_instead_of_silently_ignoring_messages():
 
 
 @pytest.mark.asyncio
+async def test_create_config_presents_monthly_price_without_hourly_microcharge(
+    monkeypatch,
+):
+    class State:
+        selected = None
+
+        async def set_state(self, value):
+            self.selected = value
+
+    async def register(*args, **kwargs):
+        return SimpleNamespace(id=1)
+
+    async def list_servers():
+        return [SimpleNamespace(id=7, location="🇳🇱", name="Amsterdam")]
+
+    monkeypatch.setattr(configs, "get_or_create_user", register)
+    monkeypatch.setattr(configs.server_service, "list", list_servers)
+    monkeypatch.setattr(configs.settings, "maintenance_mode", False)
+    monkeypatch.setattr(configs.settings, "provisioning_enabled", True)
+    monkeypatch.setattr(configs.settings, "config_creation_cost", Decimal("10.00"))
+    monkeypatch.setattr(configs.settings, "per_config_cost", Decimal("0.07"))
+    monkeypatch.setattr(configs.settings, "billing_interval", 3_600)
+    message = DummyMessage()
+    state = State()
+
+    await configs._begin_create_config(
+        message,
+        state,
+        tg_id=message.from_user.id,
+        username=message.from_user.username,
+    )
+
+    text = message.calls[-1][0]
+    assert "около 50 ₽ в месяц" in text
+    assert "небольшими частями в течение месяца" in text
+    assert "0,07 ₽" not in text
+    assert "раз в час" not in text
+    assert state.selected == CreateConfig.choosing_server
+
+
+@pytest.mark.asyncio
 async def test_group_ui_redirects_without_exposing_account_data():
     message = DummyMessage(MENU_BALANCE)
     message.chat.type = "group"
@@ -554,7 +595,8 @@ async def test_referrals_show_private_link_terms_stats_and_legacy_callback(monke
         button for row in kwargs["reply_markup"].inline_keyboard for button in row
     ]
     assert buttons[0].url.startswith("https://t.me/share/url?")
-    assert buttons[1].callback_data == "balance_history:0"
+    assert buttons[1].callback_data == "balance_history:credit:0"
+    assert buttons[2].callback_data == "balance_history:debit:0"
 
     callback = DummyCallback("refs:-1")
     callback.bot = bot

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,14 @@
+from decimal import Decimal
+
+from bot.ui import estimate_monthly_cost, format_whole_money
+
+
+def test_monthly_cost_estimate_hides_hourly_microcharge_without_overpromising():
+    estimate = estimate_monthly_cost(Decimal("0.07"), 3_600)
+
+    assert estimate == Decimal("50")
+    assert format_whole_money(estimate) == "50"
+
+
+def test_monthly_cost_estimate_tracks_runtime_tariff():
+    assert estimate_monthly_cost(Decimal("1.00"), 7_200) == Decimal("360")


### PR DESCRIPTION
## Что изменено

- Вместо мелкой почасовой цены бот показывает понятный ориентир: около 50 ₽ в месяц за конфигурацию, со списанием небольшими частями в течение месяца.
- История баланса разделена на «Пополнения и начисления» и «Списания».
- У каждого раздела независимые total, snapshot и пагинация.
- Старые Telegram callback-ссылки сохранены для совместимости.

## Почему

Текущие 0,07 ₽ в час технически соответствуют примерно 50 ₽ за 30 дней, но почасовая формулировка неудобна пользователю. Смешанная ledger-история также усложняла поиск конкретных пополнений и списаний.

## Влияние

Фактическая модель биллинга и схема БД не меняются. Фоновая отправка уведомлений не затрагивается.

## Проверки

- Полный backend suite в Docker: 253 passed, 6 skipped.
- PostgreSQL concurrency suite: 6 passed.
- Focused UI/accounting suite: 39 passed.
- Black, isort, compileall и git diff --check проходят.
- Локальный bot image успешно собран.