### PR TITLE
Add per-user activity timeline and bot audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           alembic upgrade head
           alembic current
           alembic check
-          test "$(psql 'postgresql://vpn:vpn@127.0.0.1:5432/vpn_migration' -Atc 'SELECT version_num FROM alembic_version')" = "d4e7f9a1b2c3"
+          test "$(psql 'postgresql://vpn:vpn@127.0.0.1:5432/vpn_migration' -Atc 'SELECT version_num FROM alembic_version')" = "e9f1a2b3c4d5"
 
   frontend:
     name: Frontend

--- a/admin/routers/admin_v1_users.py
+++ b/admin/routers/admin_v1_users.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import hashlib
-from datetime import datetime
+import re
+from datetime import datetime, timedelta
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
@@ -18,6 +19,7 @@ from core.services.admin_queries import (
     AdminUserQueryService,
     money,
 )
+from core.services.user_timeline import AdminUserTimelineService
 
 from ..schemas_v1 import BalanceAdjustmentRequest
 from ..security import (
@@ -37,10 +39,20 @@ router = APIRouter(prefix="/api/admin/v1/users", tags=["admin-v1-users"])
 users = AdminUserQueryService(uow)
 referrals = AdminReferralQueryService(uow)
 balances = AdminBalanceService()
+timeline = AdminUserTimelineService(uow)
 
 UsersRead = Annotated[
     AdminPrincipal,
     Depends(require_permission(AdminPermission.USERS_READ)),
+]
+TimelineRead = Annotated[
+    AdminPrincipal,
+    Depends(
+        require_permission(
+            AdminPermission.USERS_READ,
+            AdminPermission.AUDIT_READ,
+        )
+    ),
 ]
 BalanceRead = Annotated[
     AdminPrincipal,
@@ -171,6 +183,68 @@ async def get_user(user_id: int, principal: UsersRead):
     if AdminPermission.REFERRALS_READ not in principal.permissions:
         payload.pop("referral", None)
         payload.get("identity", {}).pop("referral_code", None)
+    return payload
+
+
+@router.get("/{user_id}/timeline")
+async def get_user_timeline(
+    user_id: int,
+    request: Request,
+    principal: TimelineRead,
+    category: str | None = Query(
+        default=None,
+        pattern="^(bot|finance|referral|vpn|admin|account)$",
+    ),
+    action: str | None = Query(default=None, min_length=1, max_length=96),
+    result: str | None = Query(default=None, min_length=1, max_length=32),
+    occurred_from: datetime | None = Query(default=None, alias="from"),
+    occurred_to: datetime | None = Query(default=None, alias="to"),
+    limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0, le=10_000),
+):
+    raw_to = request.query_params.get("to")
+    if (
+        occurred_to is not None
+        and raw_to
+        and re.fullmatch(r"\d{4}-\d{2}-\d{2}", raw_to)
+    ):
+        # A date selected in the UI means the entire calendar day; explicit
+        # timestamps retain the documented exclusive upper-bound semantics.
+        try:
+            occurred_to += timedelta(days=1)
+        except OverflowError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="timeline 'to' date is out of range",
+            ) from exc
+    try:
+        payload = await timeline.list_timeline(
+            user_id,
+            category=category,
+            action=action,
+            result=result,
+            occurred_from=occurred_from,
+            occurred_to=occurred_to,
+            limit=limit,
+            offset=offset,
+            include_finance=bool(
+                principal.permissions
+                & {AdminPermission.BALANCE_READ, AdminPermission.FINANCE_READ}
+            ),
+            include_referral=(AdminPermission.REFERRALS_READ in principal.permissions),
+            include_vpn=(AdminPermission.CONFIGS_READ in principal.permissions),
+            include_admin=(AdminPermission.AUDIT_READ in principal.permissions),
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    if payload is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
     return payload
 
 

--- a/admin_frontend/src/api/adapters.ts
+++ b/admin_frontend/src/api/adapters.ts
@@ -12,7 +12,11 @@ import type {
   ReferralReward,
   Server,
   ServerStatus,
+  TimelineActor,
+  TimelineCategory,
+  TimelineSource,
   User,
+  UserTimelineEvent,
   VpnConfig,
   VpnOperation,
 } from './types'
@@ -24,6 +28,10 @@ const text = (value: unknown, fallback = '') => value === null || value === unde
 const number = (value: unknown, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback
 const money = (value: unknown) => text(value, '0.00')
 const optionalMoney = (record: Json, key: string) => key in record && record[key] !== null ? money(record[key]) : undefined
+
+const timelineSources = new Set<TimelineSource>(['bot', 'ledger', 'payment', 'referral', 'vpn', 'admin', 'user'])
+const timelineCategories = new Set<TimelineCategory>(['bot', 'finance', 'referral', 'vpn', 'admin', 'account'])
+const timelineActorTypes = new Set<NonNullable<TimelineActor['type']>>(['user', 'admin', 'system'])
 
 function cents(value: unknown): bigint {
   const normalized = money(value).trim().replace(',', '.')
@@ -249,6 +257,39 @@ export function adaptAudit(value: unknown): AuditEvent {
   const actor = obj(raw.actor)
   const details = obj(raw.details ?? raw.metadata)
   return { id: raw.id, occurred_at: raw.created_at ?? raw.occurred_at, actor: actor.username ?? raw.actor ?? 'system', actor_id: actor.id ?? raw.actor_id, action: raw.action, target_type: raw.target_type, target_id: raw.target_id, result: details.outcome ?? raw.result ?? 'success', reason: details.reason ?? details.comment ?? raw.reason, ip_address: raw.ip_address, metadata: details }
+}
+
+function adaptTimelineActor(value: unknown): TimelineActor | string | null {
+  if (value === null || value === undefined) return null
+  if (typeof value !== 'object') return text(value)
+  const raw = obj(value)
+  const id = raw.id ?? raw.actor_id ?? null
+  const label = raw.label ?? raw.username ?? raw.name ?? null
+  const type = raw.type ?? raw.kind ?? raw.role
+  if (id === null && label === null && type === undefined) return null
+  return {
+    ...(timelineActorTypes.has(text(type) as NonNullable<TimelineActor['type']>) ? { type: text(type) as NonNullable<TimelineActor['type']> } : {}),
+    id,
+    label: label === null ? null : text(label),
+  }
+}
+
+export function adaptUserTimelineEvent(value: unknown): UserTimelineEvent {
+  const raw = obj(value)
+  const source = text(raw.source)
+  const category = text(raw.category)
+  return {
+    id: text(raw.id),
+    source: timelineSources.has(source as TimelineSource) ? source as TimelineSource : 'user',
+    category: timelineCategories.has(category as TimelineCategory) ? category as TimelineCategory : 'account',
+    action: text(raw.action, 'unknown'),
+    result: text(raw.result, 'success'),
+    occurred_at: text(raw.occurred_at ?? raw.created_at),
+    title: text(raw.title, raw.action ? text(raw.action) : 'Событие'),
+    description: raw.description === null || raw.description === undefined ? null : text(raw.description),
+    actor: adaptTimelineActor(raw.actor),
+    metadata: obj(raw.metadata),
+  }
 }
 
 export function adaptObservability(value: unknown): ObservabilitySummary {

--- a/admin_frontend/src/api/index.ts
+++ b/admin_frontend/src/api/index.ts
@@ -17,6 +17,7 @@ import {
   adaptServerStatus,
   adaptUserDetail,
   adaptUserListItem,
+  adaptUserTimelineEvent,
 } from './adapters'
 import type {
   AdminIdentity,
@@ -31,6 +32,7 @@ import type {
   Server,
   ServerCreateInput,
   User,
+  UserTimelineEvent,
   VpnConfig,
   VpnOperation,
 } from './types'
@@ -78,6 +80,7 @@ export const usersApi = {
   },
   children: (id: string, params: ListParams = {}) => adaptedPage<ReferralNode>(`/users/${encodeURIComponent(id)}/referrals/children`, params, adaptReferralNode),
   rewards: (id: string, params: ListParams = {}) => adaptedPage<ReferralReward>(`/users/${encodeURIComponent(id)}/referral-rewards`, params, adaptReward),
+  timeline: (id: string, params: ListParams = {}) => adaptedPage<UserTimelineEvent>(`/users/${encodeURIComponent(id)}/timeline`, params, adaptUserTimelineEvent),
   adjustBalance: (id: string, input: BalanceAdjustmentInput, key: string) =>
     request<User>(`/users/${encodeURIComponent(id)}/balance-adjustments`, {
       method: 'POST',

--- a/admin_frontend/src/api/types.ts
+++ b/admin_frontend/src/api/types.ts
@@ -264,6 +264,28 @@ export interface AuditEvent {
   metadata?: Record<string, unknown>
 }
 
+export type TimelineSource = 'bot' | 'ledger' | 'payment' | 'referral' | 'vpn' | 'admin' | 'user'
+export type TimelineCategory = 'bot' | 'finance' | 'referral' | 'vpn' | 'admin' | 'account'
+
+export interface TimelineActor {
+  type?: 'user' | 'admin' | 'system'
+  id?: string | number | null
+  label?: string | null
+}
+
+export interface UserTimelineEvent {
+  id: string
+  source: TimelineSource
+  category: TimelineCategory
+  action: string
+  result: string
+  occurred_at: string
+  title: string
+  description?: string | null
+  actor?: TimelineActor | string | null
+  metadata: Record<string, unknown>
+}
+
 export interface BalanceAdjustmentInput {
   direction: 'credit' | 'debit'
   amount: Money

--- a/admin_frontend/src/components/StatusBadge.tsx
+++ b/admin_frontend/src/components/StatusBadge.tsx
@@ -1,17 +1,17 @@
 type Tone = 'success' | 'warning' | 'danger' | 'neutral' | 'info'
 
 const statusTone: Record<string, Tone> = {
-  active: 'success', healthy: 'success', ready: 'success', completed: 'success', succeeded: 'success', confirmed: 'success', success: 'success', online: 'success', enabled: 'success',
-  pending: 'warning', queued: 'warning', retrying: 'warning', draining: 'warning', degraded: 'warning', suspended: 'warning', stale: 'warning', provisioning: 'info',
-  failed: 'danger', error: 'danger', unhealthy: 'danger', offline: 'danger', disabled: 'danger', critical: 'danger', revoked: 'danger', blocked: 'danger', deactivated: 'danger', permanent_failure: 'danger', unreachable: 'danger', instance_mismatch: 'danger',
-  info: 'info', running: 'info', processing: 'info', disabled_feature: 'neutral', retired: 'neutral', unknown: 'neutral',
+  active: 'success', healthy: 'success', ready: 'success', completed: 'success', succeeded: 'success', confirmed: 'success', credited: 'success', success: 'success', online: 'success', enabled: 'success',
+  pending: 'warning', queued: 'warning', retrying: 'warning', draining: 'warning', degraded: 'warning', suspended: 'warning', stale: 'warning', provisioning: 'info', unavailable: 'warning',
+  failed: 'danger', error: 'danger', unhealthy: 'danger', offline: 'danger', disabled: 'danger', critical: 'danger', revoked: 'danger', blocked: 'danger', deactivated: 'danger', permanent_failure: 'danger', unreachable: 'danger', instance_mismatch: 'danger', rejected: 'danger', invalid: 'danger', exhausted: 'danger',
+  info: 'info', running: 'info', processing: 'info', disabled_feature: 'neutral', retired: 'neutral', unknown: 'neutral', handled: 'neutral', processed: 'neutral', ignored: 'neutral', superseded: 'neutral',
 }
 
 const statusLabel: Record<string, string> = {
-  active: 'Активен', healthy: 'Работает', ready: 'Готов', completed: 'Завершено', succeeded: 'Завершено', confirmed: 'Подтверждено', success: 'Успешно', online: 'Онлайн', enabled: 'Включено',
+  active: 'Активен', healthy: 'Работает', ready: 'Готов', completed: 'Завершено', succeeded: 'Завершено', confirmed: 'Подтверждено', credited: 'Зачислено', success: 'Успешно', online: 'Онлайн', enabled: 'Включено',
   pending: 'Ожидает', queued: 'В очереди', retrying: 'Повтор', draining: 'Drain', degraded: 'Есть проблемы', suspended: 'Приостановлен', stale: 'Данные устарели', provisioning: 'Создаётся',
   failed: 'Ошибка', error: 'Ошибка', unhealthy: 'Не работает', offline: 'Офлайн', disabled: 'Отключён', critical: 'Критично', revoked: 'Отозван', blocked: 'Бот заблокирован', deactivated: 'Деактивирован', permanent_failure: 'Недоступен', unreachable: 'Недоступен', instance_mismatch: 'Другой instance', retired: 'Выведен',
-  running: 'Выполняется', processing: 'Обработка', unknown: 'Неизвестно', disabled_feature: 'Выключено',
+  running: 'Выполняется', processing: 'Обработка', unknown: 'Неизвестно', disabled_feature: 'Выключено', handled: 'Обработано ботом', processed: 'Обработано', rejected: 'Отклонено', invalid: 'Некорректно', unavailable: 'Недоступно', ignored: 'Пропущено', superseded: 'Заменено новой операцией', exhausted: 'Попытки исчерпаны',
 }
 
 export function StatusBadge({ value, label }: { value?: string | boolean | null; label?: string }) {

--- a/admin_frontend/src/components/UserTimeline.tsx
+++ b/admin_frontend/src/components/UserTimeline.tsx
@@ -1,0 +1,304 @@
+import { useQuery } from '@tanstack/react-query'
+import {
+  Bot,
+  CalendarDays,
+  CircleDollarSign,
+  Gift,
+  History,
+  Network,
+  RotateCcw,
+  Search,
+  ShieldCheck,
+  UserRound,
+  type LucideIcon,
+} from 'lucide-react'
+import { useEffect, useState, type FormEvent } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { usersApi, type TimelineActor, type TimelineCategory, type UserTimelineEvent } from '../api'
+import { formatDateTime } from '../lib/format'
+import { Pagination } from './Pagination'
+import { EmptyState, ErrorState, PageLoading } from './States'
+import { StatusBadge } from './StatusBadge'
+
+const PAGE_SIZE = 25
+const PARAMS = {
+  category: 'history_category',
+  action: 'history_action',
+  result: 'history_result',
+  from: 'history_from',
+  to: 'history_to',
+  offset: 'history_offset',
+} as const
+
+const categoryOptions: Array<{ value: '' | TimelineCategory; label: string; icon: LucideIcon }> = [
+  { value: '', label: 'Все события', icon: History },
+  { value: 'bot', label: 'Бот', icon: Bot },
+  { value: 'finance', label: 'Финансы', icon: CircleDollarSign },
+  { value: 'vpn', label: 'VPN', icon: Network },
+  { value: 'referral', label: 'Рефералы', icon: Gift },
+  { value: 'admin', label: 'Администраторы', icon: ShieldCheck },
+  { value: 'account', label: 'Аккаунт', icon: UserRound },
+]
+
+const categoryLabel: Record<TimelineCategory, string> = {
+  bot: 'Telegram-бот',
+  finance: 'Финансы',
+  vpn: 'VPN',
+  referral: 'Рефералы',
+  admin: 'Администратор',
+  account: 'Аккаунт',
+}
+
+const actionLabels: Record<string, string> = {
+  'navigation.start': 'Запущен бот',
+  'navigation.menu': 'Открыто главное меню',
+  'navigation.help': 'Открыта помощь',
+  'navigation.cancel': 'Действие отменено',
+  'navigation.instructions_open': 'Открыты инструкции',
+  'navigation.guide_open': 'Открыта инструкция для устройства',
+  'finance.balance_view': 'Просмотрен баланс',
+  'finance.balance_history': 'Открыта детализация баланса',
+  'finance.topup_open': 'Запрошено пополнение',
+  'finance.payment_provider_select': 'Выбран способ оплаты',
+  'finance.payment_amount_select': 'Выбрана сумма пополнения',
+  'finance.payment_pre_checkout': 'Проверка платежа в Telegram',
+  'finance.payment_successful': 'Telegram сообщил об успешном платеже',
+  'vpn.config_list': 'Запрошен список конфигураций',
+  'vpn.config_view': 'Запрошен просмотр VPN-конфигурации',
+  'vpn.config_create_start': 'Запрошено создание конфигурации',
+  'vpn.config_create_submit': 'Отправлена заявка на создание конфигурации',
+  'vpn.config_server_select': 'Выбран VPN-сервер',
+  'vpn.config_suspend': 'Запрошена приостановка конфигурации',
+  'vpn.config_resume': 'Запрошено возобновление конфигурации',
+  'vpn.config_delete_request': 'Запрошено удаление конфигурации',
+  'vpn.config_delete_confirm': 'Подтверждено удаление конфигурации',
+  'vpn.config_download': 'Запрошено скачивание VPN-конфигурации',
+  'vpn.config_rename_start': 'Начато переименование конфигурации',
+  'vpn.config_rename_submit': 'Конфигурация переименована',
+  'referral.overview': 'Открыта реферальная программа',
+  'message.command_received': 'Отправлена команда боту',
+  'message.received': 'Отправлено сообщение боту',
+  'message.unrecognized': 'Сообщение не распознано',
+  'callback.received': 'Нажата кнопка в боте',
+  'update.received': 'Получено событие Telegram',
+  'privacy.non_private_input': 'Обращение к боту вне личного чата',
+  'access.invite_lookup': 'Проверен доступ по приглашению',
+  'access.invite_required': 'Доступ без приглашения отклонён',
+  'bot.command.received': 'Отправлена команда боту',
+  'bot.callback.received': 'Нажата кнопка в боте',
+  'bot.message.received': 'Отправлено сообщение боту',
+  'bot.start': 'Запущен бот',
+  'bot.balance.opened': 'Открыт баланс',
+  'bot.configs.opened': 'Открыты конфигурации',
+  'bot.payment.opened': 'Открыто пополнение',
+  'bot.instructions.opened': 'Открыты инструкции',
+  'bot.referrals.opened': 'Открыта реферальная программа',
+  'payment.created': 'Создан платёж',
+  'payment.credited': 'Платёж зачислен',
+  'balance.credited': 'Баланс пополнен',
+  'balance.debited': 'Средства списаны',
+  'referral.reward.credited': 'Начислено реферальное вознаграждение',
+  'vpn.config.created': 'Создана VPN-конфигурация',
+  'vpn.config.suspended': 'VPN-конфигурация приостановлена',
+  'vpn.config.unsuspended': 'VPN-конфигурация возобновлена',
+  'vpn.config.revoked': 'VPN-конфигурация отозвана',
+  'account.registered': 'Пользователь зарегистрирован',
+  'account.delivery_status.changed': 'Изменился статус Telegram',
+  'admin.balance.adjusted': 'Администратор изменил баланс',
+}
+
+const resultLabels: Record<string, string> = {
+  handled: 'Обработано ботом',
+  processed: 'Обработано',
+  success: 'Успешно',
+  succeeded: 'Успешно',
+  completed: 'Завершено',
+  credited: 'Зачислено',
+  accepted: 'Принято',
+  pending: 'Ожидает',
+  queued: 'В очереди',
+  running: 'Выполняется',
+  processing: 'Выполняется',
+  failed: 'Ошибка',
+  error: 'Ошибка',
+  rejected: 'Отклонено',
+  blocked: 'Бот заблокирован',
+  deactivated: 'Деактивирован',
+  cancelled: 'Отменено',
+  expired: 'Истёк',
+  ignored: 'Пропущено',
+  invalid: 'Некорректное действие',
+  unavailable: 'Недоступно',
+  superseded: 'Заменено новой операцией',
+  exhausted: 'Попытки исчерпаны',
+}
+
+const sensitiveKey = /(^|[_-])(authorization|cookie|credential|password|passwd|secret|token|api[_-]?key|private[_-]?key|access[_-]?key)($|[_-])/i
+
+function safeMetadata(value: unknown, depth = 0): unknown {
+  if (depth >= 5) return '[сокращено]'
+  if (Array.isArray(value)) {
+    const items = value.slice(0, 30).map((item) => safeMetadata(item, depth + 1))
+    return value.length > 30 ? [...items, `[ещё ${value.length - 30}]`] : items
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>).slice(0, 60)
+    const result = Object.fromEntries(entries.map(([key, item]) => [key, sensitiveKey.test(key) ? '[скрыто]' : safeMetadata(item, depth + 1)]))
+    if (Object.keys(value).length > entries.length) result['…'] = `[ещё ${Object.keys(value).length - entries.length} полей]`
+    return result
+  }
+  if (typeof value === 'string' && value.length > 800) return `${value.slice(0, 800)}…`
+  return value
+}
+
+function actorLabel(actor: TimelineActor | string | null | undefined) {
+  if (!actor) return 'Система'
+  if (typeof actor === 'string') return actor
+  if (actor.label) return actor.label
+  if (actor.type === 'user') return actor.id ? `Пользователь #${actor.id}` : 'Пользователь'
+  if (actor.type === 'admin') return actor.id ? `Администратор #${actor.id}` : 'Администратор'
+  return 'Система'
+}
+
+function actionLabel(action: string) {
+  if (actionLabels[action]) return actionLabels[action]
+  return action.replace(/[._-]+/g, ' ').replace(/^./, (letter) => letter.toUpperCase())
+}
+
+function TimelineItem({ event }: { event: UserTimelineEvent }) {
+  const option = categoryOptions.find((item) => item.value === event.category) ?? categoryOptions[0]
+  const Icon = option.icon
+  const details = safeMetadata(event.metadata) as Record<string, unknown>
+  const hasDetails = Object.keys(details).length > 0
+  const result = event.result.toLowerCase()
+  return (
+    <li className={`timeline-event timeline-event--${event.category}`}>
+      <span className="timeline-event__icon" aria-hidden="true"><Icon /></span>
+      <article>
+        <header>
+          <div>
+            <strong>{event.title || actionLabel(event.action)}</strong>
+            <span>{categoryLabel[event.category]} · {actionLabel(event.action)}</span>
+          </div>
+          <StatusBadge value={result} label={resultLabels[result] ?? event.result} />
+        </header>
+        {event.description && <p>{event.description}</p>}
+        <footer>
+          <time dateTime={event.occurred_at}>{formatDateTime(event.occurred_at)}</time>
+          <span>{actorLabel(event.actor)}</span>
+          <code title={event.action}>{event.action}</code>
+        </footer>
+        {hasDetails && <details className="timeline-event__details"><summary>Технические детали</summary><pre>{JSON.stringify(details, null, 2)}</pre></details>}
+      </article>
+    </li>
+  )
+}
+
+function validCategory(value: string | null): '' | TimelineCategory {
+  return categoryOptions.some((option) => option.value === value) ? value as '' | TimelineCategory : ''
+}
+
+function validOffset(value: string | null) {
+  const parsed = Number(value ?? 0)
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : 0
+}
+
+function localDayBoundary(
+  value: string,
+  { exclusiveEnd = false }: { exclusiveEnd?: boolean } = {},
+) {
+  if (!value) return undefined
+  const [year, month, day] = value.split('-').map(Number)
+  const boundary = new Date(year, month - 1, day + (exclusiveEnd ? 1 : 0))
+  return Number.isNaN(boundary.getTime()) ? undefined : boundary.toISOString()
+}
+
+export function UserTimeline({ userId }: { userId: string }) {
+  const [params, setParams] = useSearchParams()
+  const category = validCategory(params.get(PARAMS.category))
+  const action = params.get(PARAMS.action) ?? ''
+  const result = params.get(PARAMS.result) ?? ''
+  const from = params.get(PARAMS.from) ?? ''
+  const to = params.get(PARAMS.to) ?? ''
+  const offset = validOffset(params.get(PARAMS.offset))
+  const [actionDraft, setActionDraft] = useState(action)
+  const [fromDraft, setFromDraft] = useState(from)
+  const [toDraft, setToDraft] = useState(to)
+  const [dateError, setDateError] = useState('')
+
+  useEffect(() => { setActionDraft(action) }, [action])
+  useEffect(() => { setFromDraft(from) }, [from])
+  useEffect(() => { setToDraft(to) }, [to])
+
+  const query = useQuery({
+    queryKey: ['user-timeline', userId, category, action, result, from, to, offset],
+    queryFn: () => usersApi.timeline(userId, {
+      category: category || undefined,
+      action: action || undefined,
+      result: result || undefined,
+      from: localDayBoundary(from),
+      to: localDayBoundary(to, { exclusiveEnd: true }),
+      limit: PAGE_SIZE,
+      offset,
+    }),
+    placeholderData: (previous) => previous,
+  })
+
+  const setFilter = (key: string, value: string) => {
+    const next = new URLSearchParams(params)
+    if (value) next.set(key, value); else next.delete(key)
+    if (key !== PARAMS.offset) next.delete(PARAMS.offset)
+    setParams(next)
+  }
+
+  const applyAdvancedFilters = (event: FormEvent) => {
+    event.preventDefault()
+    if (fromDraft && toDraft && fromDraft > toDraft) {
+      setDateError('Начальная дата не может быть позже конечной')
+      return
+    }
+    setDateError('')
+    const next = new URLSearchParams(params)
+    for (const [key, value] of [[PARAMS.action, actionDraft.trim()], [PARAMS.from, fromDraft], [PARAMS.to, toDraft]]) {
+      if (value) next.set(key, value); else next.delete(key)
+    }
+    next.delete(PARAMS.offset)
+    setParams(next)
+  }
+
+  const clearFilters = () => {
+    const next = new URLSearchParams(params)
+    Object.values(PARAMS).forEach((key) => next.delete(key))
+    setDateError('')
+    setParams(next)
+  }
+
+  const filtered = Boolean(category || action || result || from || to)
+
+  return (
+    <section className="panel timeline-panel">
+      <header className="panel__header">
+        <div><h2>История пользователя</h2><p>Действия в боте, финансы, VPN, рефералы и административные изменения в одной хронологии</p></div>
+        {query.isFetching && !query.isLoading && <span className="timeline-refresh" role="status">Обновляем…</span>}
+      </header>
+      <div className="timeline-filters">
+        <div className="timeline-categories" role="group" aria-label="Категория событий">
+          {categoryOptions.map((option) => {
+            const Icon = option.icon
+            return <button key={option.value || 'all'} type="button" className={category === option.value ? 'timeline-category timeline-category--active' : 'timeline-category'} aria-pressed={category === option.value} onClick={() => setFilter(PARAMS.category, option.value)}><Icon aria-hidden="true" />{option.label}</button>
+          })}
+        </div>
+        <form className="timeline-filter-form" onSubmit={applyAdvancedFilters}>
+          <label className="timeline-action-search"><Search aria-hidden="true" /><span className="sr-only">Действие</span><input aria-label="Действие" value={actionDraft} onChange={(event) => setActionDraft(event.target.value)} placeholder="Действие, например navigation.start" /></label>
+          <label>Результат<select aria-label="Результат события" value={result} onChange={(event) => setFilter(PARAMS.result, event.target.value)}><option value="">Все</option><option value="handled">Обработано ботом</option><option value="processed">Обработано (старые события)</option><option value="completed">Завершено</option><option value="success">Успешно</option><option value="succeeded">Успешно (провайдер)</option><option value="credited">Зачислено</option><option value="accepted">Принято</option><option value="pending">Ожидает</option><option value="queued">В очереди</option><option value="running">Выполняется</option><option value="processing">Обрабатывается</option><option value="rejected">Отклонено</option><option value="invalid">Некорректно</option><option value="unavailable">Недоступно</option><option value="ignored">Пропущено</option><option value="failed">Ошибка</option><option value="exhausted">Попытки исчерпаны</option><option value="superseded">Заменено новой операцией</option><option value="blocked">Бот заблокирован</option><option value="deactivated">Деактивирован</option></select></label>
+          <label>С даты<input aria-label="С даты" type="date" value={fromDraft} onChange={(event) => setFromDraft(event.target.value)} /></label>
+          <label>По дату<input aria-label="По дату" type="date" value={toDraft} onChange={(event) => setToDraft(event.target.value)} /></label>
+          <button className="button button--secondary button--small" type="submit"><CalendarDays /> Применить</button>
+          {filtered && <button className="button button--ghost button--small" type="button" onClick={clearFilters}><RotateCcw /> Сбросить</button>}
+        </form>
+        {dateError && <p className="timeline-filter-error" role="alert">{dateError}</p>}
+      </div>
+      {query.isLoading ? <PageLoading label="Загружаем историю…" /> : query.isError ? <ErrorState error={query.error} retry={() => void query.refetch()} /> : query.data!.items.length ? <><ol className="timeline-list">{query.data!.items.map((event) => <TimelineItem key={event.id} event={event} />)}</ol><Pagination offset={query.data!.offset} limit={query.data!.limit} total={query.data!.total} onChange={(nextOffset) => setFilter(PARAMS.offset, nextOffset ? String(nextOffset) : '')} /></> : <EmptyState title={filtered ? 'По фильтрам событий не найдено' : 'История пока пуста'} description={filtered ? 'Измените или сбросьте фильтры.' : 'События появятся после действий пользователя или системы.'} action={filtered ? <button type="button" className="button button--secondary" onClick={clearFilters}>Сбросить фильтры</button> : undefined} />}
+    </section>
+  )
+}

--- a/admin_frontend/src/pages/UserDetailPage.tsx
+++ b/admin_frontend/src/pages/UserDetailPage.tsx
@@ -1,11 +1,9 @@
 import { useQuery } from '@tanstack/react-query'
-import { ArrowLeft, CircleDollarSign, ExternalLink, ShieldAlert } from 'lucide-react'
+import { ArrowLeft, CircleDollarSign, ShieldAlert } from 'lucide-react'
 import { useState } from 'react'
 import { Link, Navigate, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import {
-  auditApi,
   usersApi,
-  type AuditEvent,
   type LedgerEntry,
   type Payment,
   type ReferralNode,
@@ -20,6 +18,7 @@ import { PageHeader, StatCard } from '../components/PageHeader'
 import { Pagination } from '../components/Pagination'
 import { EmptyState, ErrorState, ForbiddenState, PageLoading } from '../components/States'
 import { StatusBadge } from '../components/StatusBadge'
+import { UserTimeline } from '../components/UserTimeline'
 import { formatDateTime, formatMoney, formatNumber, shortId, userLabel } from '../lib/format'
 
 const DETAIL_PAGE_SIZE = 25
@@ -41,7 +40,7 @@ const tabs = [
   { id: 'finance', label: 'Финансы', permission: 'balance:read' },
   { id: 'configs', label: 'Конфигурации', permission: 'configs:read' },
   { id: 'referrals', label: 'Рефералы', permission: 'referrals:read' },
-  { id: 'audit', label: 'Аудит', permission: 'audit:read' },
+  { id: 'history', label: 'История', permission: 'audit:read' },
 ]
 
 export function UserDetailPage() {
@@ -57,6 +56,7 @@ export function UserDetailPage() {
   const navigate = useNavigate()
   const [balanceOpen, setBalanceOpen] = useState(false)
   const userQuery = useQuery({ queryKey: ['user', userId], queryFn: () => usersApi.detail(userId), enabled: Boolean(userId) })
+  if (tab === 'audit') return <Navigate to={`/users/${userId}/history`} replace />
   if (!tabs.some((item) => item.id === tab)) return <Navigate to={`/users/${userId}/overview`} replace />
   const tabAllowed = tabs.find((item) => item.id === tab)?.permission
   const canOpenTab = tabAllowed ? admin?.permissions.includes(tabAllowed) ?? false : false
@@ -72,7 +72,7 @@ export function UserDetailPage() {
         <div className="user-summary__stats">{canReadBalance && <><StatCard label="Баланс" value={formatMoney(user.balance)} /><StatCard label="Пополнения" value={formatMoney(user.deposits_total)} /><StatCard label="Потребление" value={formatMoney(user.service_spend_total)} /></>}<StatCard label="Активные конфиги" value={formatNumber(user.active_configs_count ?? user.configs_count)} /></div>
       </section>
       <nav className="tabs" aria-label="Разделы пользователя">{tabs.filter((item) => admin?.permissions.includes(item.permission)).map((item) => <Link key={item.id} className={tab === item.id ? 'tab tab--active' : 'tab'} to={`/users/${userId}/${item.id}`}>{item.label}</Link>)}</nav>
-      {!canOpenTab ? <ForbiddenState /> : <>{tab === 'overview' && <UserOverview userId={userId} user={user} canReadBalance={canReadBalance} canReadReferrals={canReadReferrals} canReadConfigs={canReadConfigs} canReadOperations={canReadOperations} />}{tab === 'finance' && <UserFinance userId={userId} />}{tab === 'configs' && <UserConfigs userId={userId} canReadServers={canReadServers} />}{tab === 'referrals' && <UserReferrals userId={userId} />}{tab === 'audit' && <UserAudit userId={userId} />}</>}
+      {!canOpenTab ? <ForbiddenState /> : <>{tab === 'overview' && <UserOverview userId={userId} user={user} canReadBalance={canReadBalance} canReadReferrals={canReadReferrals} canReadConfigs={canReadConfigs} canReadOperations={canReadOperations} />}{tab === 'finance' && <UserFinance userId={userId} />}{tab === 'configs' && <UserConfigs userId={userId} canReadServers={canReadServers} />}{tab === 'referrals' && <UserReferrals userId={userId} />}{tab === 'history' && <UserTimeline userId={userId} />}</>}
       {canAdjustBalance && user.balance !== undefined && <BalanceAdjustmentDialog user={user} open={balanceOpen} onClose={() => setBalanceOpen(false)} />}
     </>
   )
@@ -162,19 +162,4 @@ function UserReferrals({ userId }: { userId: string }) {
 
 function ReferralList({ nodes }: { nodes: ReferralNode[] }) {
   return <div className="referral-list">{nodes.map((node) => <div className="referral-row" key={node.user_id}><span className="avatar">{(node.username || String(node.user_id)).slice(0, 1).toUpperCase()}</span><span><Link className="primary-link" to={`/users/${node.user_id}`}>{node.username ? `@${node.username}` : `Пользователь #${node.user_id}`}</Link><small>Регистрация {formatDateTime(node.registered_at)}</small></span><span><small>Пополнения</small><strong>{formatMoney(node.deposits_total)}</strong></span><span><small>Начисления</small><strong>{formatMoney(node.rewards_total)}</strong></span><span><small>Своя сеть</small><strong>{formatNumber(node.direct_referrals)}</strong></span></div>)}</div>
-}
-
-function UserAudit({ userId }: { userId: string }) {
-  const [params, setParams] = useSearchParams()
-  const offset = pageOffset(params, 'audit_offset')
-  const query = useQuery({ queryKey: ['user-audit', userId, offset], queryFn: () => auditApi.list({ target_type: 'user', target_id: userId, limit: DETAIL_PAGE_SIZE, offset }), placeholderData: (previous) => previous })
-  const columns: Column<AuditEvent>[] = [
-    { key: 'time', header: 'Время', render: (row) => formatDateTime(row.occurred_at) },
-    { key: 'actor', header: 'Инициатор', render: (row) => row.actor || 'system' },
-    { key: 'action', header: 'Действие', render: (row) => <span className="mono-soft">{row.action || '—'}</span> },
-    { key: 'reason', header: 'Причина', render: (row) => row.reason || '—' },
-    { key: 'result', header: 'Результат', render: (row) => <StatusBadge value={row.result} /> },
-    { key: 'meta', header: '', render: (row) => row.metadata && Object.keys(row.metadata).length ? <details className="details-popover"><summary><ExternalLink size={15} /> Детали</summary><pre>{JSON.stringify(row.metadata, null, 2)}</pre></details> : null },
-  ]
-  return <section className="panel"><header className="panel__header"><div><h2>История действий</h2><p>Неизменяемый журнал по пользователю</p></div></header>{query.isLoading ? <PageLoading /> : query.isError ? <ErrorState error={query.error} /> : query.data!.items.length ? <><DataTable label="Аудит пользователя" columns={columns} rows={query.data!.items} rowKey={(row) => row.id} /><Pagination offset={query.data!.offset} limit={query.data!.limit} total={query.data!.total} onChange={(nextOffset) => updatePage(params, setParams, 'audit_offset', nextOffset)} /></> : <EmptyState title="Событий пока нет" />}</section>
 }

--- a/admin_frontend/src/styles.css
+++ b/admin_frontend/src/styles.css
@@ -387,6 +387,48 @@ select { min-height: 34px; padding: 6px 30px 6px 9px; font-size: 11px; }
 .external-links a { display: flex; align-items: center; justify-content: space-between; padding: 10px 0; border-bottom: 1px solid var(--line); font-size: 10px; font-weight: 700; }
 .external-links a:last-child { border-bottom: 0; }
 
+.timeline-panel { overflow: hidden; }
+.timeline-refresh { color: var(--muted); font-size: 10px; }
+.timeline-filters { padding: 14px 18px; border-bottom: 1px solid var(--line); background: #fafafd; }
+.timeline-categories { display: flex; gap: 6px; overflow-x: auto; padding-bottom: 10px; }
+.timeline-category { display: inline-flex; min-height: 32px; flex: 0 0 auto; align-items: center; gap: 6px; padding: 6px 10px; border: 1px solid var(--line); border-radius: 999px; color: #66677a; background: #fff; font-size: 10px; font-weight: 650; }
+.timeline-category svg { width: 14px; height: 14px; }
+.timeline-category:hover { border-color: #c9c5ee; color: var(--primary); }
+.timeline-category--active { border-color: #c7c1f1; color: var(--primary); background: var(--primary-soft); box-shadow: inset 0 0 0 1px rgba(100,87,217,.08); }
+.timeline-filter-form { display: grid; grid-template-columns: minmax(210px, 1fr) auto auto auto auto auto; gap: 8px; align-items: end; }
+.timeline-filter-form > label:not(.timeline-action-search) { display: flex; flex-direction: column; gap: 4px; color: var(--muted); font-size: 9px; font-weight: 650; }
+.timeline-filter-form input, .timeline-filter-form select { min-height: 34px; padding: 6px 9px; font-size: 10px; }
+.timeline-filter-form select { padding-right: 28px; }
+.timeline-filter-form .button svg { width: 14px; height: 14px; }
+.timeline-action-search { display: flex; min-height: 34px; align-items: center; gap: 7px; padding: 0 9px; border: 1px solid #dcdde6; border-radius: 8px; background: #fff; }
+.timeline-action-search:focus-within { border-color: var(--primary); box-shadow: 0 0 0 3px rgba(100,87,217,.09); }
+.timeline-action-search svg { width: 14px; color: #9697a8; }
+.timeline-action-search input { min-width: 0; flex: 1; padding: 0; border: 0; outline: 0; }
+.timeline-filter-error { margin: 9px 0 0; color: var(--danger); font-size: 10px; }
+.timeline-list { margin: 0; padding: 4px 18px 8px; list-style: none; }
+.timeline-event { position: relative; display: grid; grid-template-columns: 35px minmax(0,1fr); gap: 12px; padding: 14px 0; }
+.timeline-event:not(:last-child)::before { position: absolute; top: 44px; bottom: -4px; left: 17px; width: 1px; background: #e3e3eb; content: ''; }
+.timeline-event__icon { z-index: 1; display: grid; width: 35px; height: 35px; place-items: center; border: 1px solid #ddd9fb; border-radius: 10px; color: var(--primary); background: var(--primary-soft); }
+.timeline-event__icon svg { width: 16px; height: 16px; }
+.timeline-event--bot .timeline-event__icon { border-color: #cde3fa; color: #337dba; background: #edf6ff; }
+.timeline-event--finance .timeline-event__icon { border-color: #cdebdc; color: #238463; background: #edfaf4; }
+.timeline-event--vpn .timeline-event__icon { border-color: #d9d4fb; color: #5b4fc5; background: #f0eefc; }
+.timeline-event--referral .timeline-event__icon { border-color: #f0dfbc; color: #9a6c1f; background: #fff8e9; }
+.timeline-event--admin .timeline-event__icon { border-color: #ead0d6; color: #a84458; background: #fff0f3; }
+.timeline-event--account .timeline-event__icon { border-color: #dadbe3; color: #636477; background: #f4f4f7; }
+.timeline-event article { min-width: 0; padding: 12px 14px; border: 1px solid var(--line); border-radius: 11px; background: #fff; }
+.timeline-event article > header { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
+.timeline-event article > header > div { display: flex; min-width: 0; flex-direction: column; gap: 4px; }
+.timeline-event article > header strong { color: #333448; font-size: 11px; line-height: 1.4; }
+.timeline-event article > header span:not(.status) { color: var(--muted); font-size: 9px; }
+.timeline-event article > p { margin: 9px 0 0; color: #55566a; font-size: 10px; line-height: 1.55; overflow-wrap: anywhere; }
+.timeline-event article > footer { display: flex; flex-wrap: wrap; align-items: center; gap: 5px 12px; margin-top: 10px; color: #9293a3; font-size: 9px; }
+.timeline-event article > footer span::before { margin-right: 12px; color: #c5c5ce; content: '\2022'; }
+.timeline-event article > footer code { max-width: 100%; padding: 3px 6px; overflow: hidden; border-radius: 5px; color: #66677a; background: var(--surface-soft); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
+.timeline-event__details { margin-top: 9px; border-top: 1px dashed #dedee7; }
+.timeline-event__details summary { width: fit-content; padding-top: 9px; color: var(--primary); font-size: 9px; font-weight: 650; cursor: pointer; }
+.timeline-event__details pre { max-height: 300px; margin: 9px 0 0; overflow: auto; padding: 11px; border-radius: 8px; color: #dcdeea; background: #242538; font-size: 9px; line-height: 1.55; white-space: pre-wrap; overflow-wrap: anywhere; }
+
 .details-popover { position: relative; }
 .details-popover summary { display: inline-flex; align-items: center; gap: 4px; color: var(--primary); font-size: 9px; cursor: pointer; list-style: none; }
 .details-popover summary::-webkit-details-marker { display: none; }
@@ -403,6 +445,8 @@ select { min-height: 34px; padding: 6px 30px 6px 9px; font-size: 11px; }
   .server-grid { grid-template-columns: repeat(2,minmax(270px,1fr)); }
   .user-summary { grid-template-columns: 1fr; }
   .user-summary__stats .stat-card:first-child { border-left: 0; }
+  .timeline-filter-form { grid-template-columns: minmax(220px, 1fr) repeat(3, auto); }
+  .timeline-filter-form .button { align-self: end; }
 }
 
 @media (max-width: 980px) {
@@ -415,6 +459,8 @@ select { min-height: 34px; padding: 6px 30px 6px 9px; font-size: 11px; }
   .topbar { padding: 0 20px; }
   .main-content { padding: 26px 22px 45px; }
   .content-grid--finance, .content-grid--server, .content-grid--monitor { grid-template-columns: 1fr; }
+  .timeline-filter-form { grid-template-columns: repeat(2, minmax(0,1fr)); }
+  .timeline-action-search { grid-column: 1 / -1; }
   .login-page { grid-template-columns: 1fr; }
   .login-hero { display: none; }
   .login-form-wrap { min-height: 100vh; }
@@ -464,6 +510,16 @@ select { min-height: 34px; padding: 6px 30px 6px 9px; font-size: 11px; }
   .modal-backdrop { padding: 0; align-items: end; }
   .modal { width: 100%; max-height: 90vh; border-radius: 16px 16px 0 0; }
   .login-form-wrap { padding: 24px; }
+  .timeline-filters { padding: 12px; }
+  .timeline-filter-form { grid-template-columns: 1fr; }
+  .timeline-action-search { grid-column: auto; }
+  .timeline-filter-form .button { width: 100%; }
+  .timeline-list { padding: 3px 12px 7px; }
+  .timeline-event { grid-template-columns: 30px minmax(0,1fr); gap: 8px; }
+  .timeline-event:not(:last-child)::before { top: 39px; left: 14px; }
+  .timeline-event__icon { width: 30px; height: 30px; border-radius: 8px; }
+  .timeline-event article { padding: 11px; }
+  .timeline-event article > header { flex-direction: column; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/admin_frontend/src/test/user-timeline.test.tsx
+++ b/admin_frontend/src/test/user-timeline.test.tsx
@@ -1,0 +1,121 @@
+import { http, HttpResponse } from 'msw'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import App from '../App'
+import { usersApi } from '../api'
+import { actor } from './fixtures'
+import { renderApp } from './render'
+import { server } from './server'
+
+const userDetail = {
+  identity: { id: 42, tg_id: 123456, username: 'alice', delivery_status: 'active', created_at: '2026-07-10T10:00:00Z' },
+  finance: { balance: '125.50', provider_deposits: '500.00', service_charges: '20.00', config_fees: '5.00' },
+  configs: { total: 2, active: 1, suspended: 1 },
+  referral: { referrer: null, total_earned: '10.00' },
+}
+
+const timelineItem = {
+  id: 'bot:100',
+  source: 'bot',
+  category: 'bot',
+  action: 'finance.balance_view',
+  result: 'handled',
+  occurred_at: '2026-07-14T10:30:00Z',
+  title: 'Открыт раздел баланса',
+  description: 'Пользователь нажал кнопку «Баланс».',
+  actor: { type: 'user', id: 42, label: '@alice' },
+  metadata: { section: 'balance', bot_token: 'super-secret', nested: { password: 'also-secret' } },
+}
+
+test('timeline API follows the filtering contract and adapts its actor', async () => {
+  let requested: URL | undefined
+  server.use(http.get('/api/admin/v1/users/42/timeline', ({ request }) => {
+    requested = new URL(request.url)
+    return HttpResponse.json({ items: [timelineItem], total: 1, limit: 25, offset: 0 })
+  }))
+
+  const page = await usersApi.timeline('42', {
+    category: 'bot',
+    action: 'finance.balance_view',
+    result: 'handled',
+    from: '2026-07-01',
+    to: '2026-07-14',
+    limit: 25,
+    offset: 0,
+  })
+
+  expect(requested?.pathname).toBe('/api/admin/v1/users/42/timeline')
+  expect(Object.fromEntries(requested!.searchParams)).toMatchObject({
+    category: 'bot',
+    action: 'finance.balance_view',
+    result: 'handled',
+    from: '2026-07-01',
+    to: '2026-07-14',
+    limit: '25',
+    offset: '0',
+  })
+  expect(page.items[0]).toMatchObject({
+    id: 'bot:100',
+    source: 'bot',
+    category: 'bot',
+    actor: { type: 'user', id: 42, label: '@alice' },
+  })
+})
+
+test('renders the unified history, protects sensitive details and applies filters', async () => {
+  const requests: URL[] = []
+  server.use(
+    http.get('/api/admin/v1/auth/me', () => HttpResponse.json(actor)),
+    http.get('/api/admin/v1/users/42', () => HttpResponse.json(userDetail)),
+    http.get('/api/admin/v1/users/42/timeline', ({ request }) => {
+      requests.push(new URL(request.url))
+      return HttpResponse.json({ items: [timelineItem], total: 30, limit: 25, offset: Number(new URL(request.url).searchParams.get('offset') ?? 0) })
+    }),
+  )
+
+  renderApp(<App />, '/users/42/history')
+  expect(await screen.findByRole('heading', { name: 'История пользователя' })).toBeInTheDocument()
+  expect(screen.getByRole('link', { name: 'История' })).toHaveAttribute('href', '/users/42/history')
+  expect(await screen.findByText('Открыт раздел баланса')).toBeInTheDocument()
+  expect(screen.getByText('Telegram-бот · Просмотрен баланс')).toBeInTheDocument()
+  expect(screen.getAllByText('@alice').length).toBeGreaterThan(0)
+  expect(screen.queryByText('super-secret')).not.toBeInTheDocument()
+
+  const user = userEvent.setup()
+  await user.click(screen.getByText('Технические детали'))
+  expect(screen.getAllByText(/\[скрыто\]/).length).toBeGreaterThan(0)
+  expect(screen.queryByText(/super-secret|also-secret/)).not.toBeInTheDocument()
+
+  await user.click(screen.getByRole('button', { name: 'Бот' }))
+  await user.selectOptions(screen.getByLabelText('Результат события'), 'failed')
+  await user.type(screen.getByLabelText('Действие'), 'navigation.start')
+  await user.type(screen.getByLabelText('С даты'), '2026-07-01')
+  await user.type(screen.getByLabelText('По дату'), '2026-07-14')
+  await user.click(screen.getByRole('button', { name: /Применить/ }))
+
+  await waitFor(() => expect(requests.at(-1)?.searchParams.get('action')).toBe('navigation.start'))
+  const filtered = requests.at(-1)!
+  expect(filtered.searchParams.get('category')).toBe('bot')
+  expect(filtered.searchParams.get('result')).toBe('failed')
+  expect(filtered.searchParams.get('from')).toBe(new Date(2026, 6, 1).toISOString())
+  expect(filtered.searchParams.get('to')).toBe(new Date(2026, 6, 15).toISOString())
+
+  await user.click(screen.getByRole('button', { name: 'Следующая страница' }))
+  await waitFor(() => expect(requests.at(-1)?.searchParams.get('offset')).toBe('25'))
+})
+
+test('does not request user history without audit:read', async () => {
+  let timelineCalled = false
+  server.use(
+    http.get('/api/admin/v1/auth/me', () => HttpResponse.json({ actor: { id: 2, username: 'support', role: 'support', permissions: ['users:read'] }, csrf_token: 'csrf' })),
+    http.get('/api/admin/v1/users/42', () => HttpResponse.json({ identity: userDetail.identity, configs: userDetail.configs })),
+    http.get('/api/admin/v1/users/42/timeline', () => {
+      timelineCalled = true
+      return HttpResponse.json({ items: [], total: 0, limit: 25, offset: 0 })
+    }),
+  )
+
+  renderApp(<App />, '/users/42/history')
+  expect(await screen.findByText('Нет доступа к разделу')).toBeInTheDocument()
+  expect(timelineCalled).toBe(false)
+})

--- a/alembic/versions/e9f1a2b3c4d5_telegram_user_action_timeline.py
+++ b/alembic/versions/e9f1a2b3c4d5_telegram_user_action_timeline.py
@@ -1,0 +1,170 @@
+"""add immutable Telegram user actions for the admin timeline
+
+Revision ID: e9f1a2b3c4d5
+Revises: d4e7f9a1b2c3
+Create Date: 2026-07-14 12:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "e9f1a2b3c4d5"
+down_revision: Union[str, None] = "d4e7f9a1b2c3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _install_immutability_guard() -> None:
+    if op.get_bind().dialect.name != "postgresql":
+        return
+    op.execute(
+        sa.text(
+            """
+            CREATE OR REPLACE FUNCTION vpn_reject_telegram_user_action_mutation()
+            RETURNS trigger AS $$
+            BEGIN
+                RAISE EXCEPTION 'telegram_user_action_event rows are immutable';
+            END;
+            $$ LANGUAGE plpgsql
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER trg_telegram_user_action_immutable
+            BEFORE UPDATE OR DELETE ON telegram_user_action_event
+            FOR EACH ROW EXECUTE FUNCTION vpn_reject_telegram_user_action_mutation()
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER trg_telegram_user_action_no_truncate
+            BEFORE TRUNCATE ON telegram_user_action_event
+            FOR EACH STATEMENT EXECUTE FUNCTION vpn_reject_telegram_user_action_mutation()
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    op.create_table(
+        "telegram_user_action_event",
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("source_update_id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "category",
+            sa.String(length=16),
+            nullable=False,
+            server_default="bot",
+        ),
+        sa.Column("action", sa.String(length=96), nullable=False),
+        sa.Column("result", sa.String(length=24), nullable=False),
+        sa.Column("metadata", sa.JSON(), nullable=False),
+        sa.Column(
+            "occurred_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.CheckConstraint(
+            "source_update_id >= 0",
+            name="ck_telegram_user_action_nonnegative_update_id",
+        ),
+        sa.CheckConstraint(
+            "category = 'bot'",
+            name="ck_telegram_user_action_category",
+        ),
+        sa.CheckConstraint(
+            "result IN ('handled', 'completed', 'rejected', 'ignored', "
+            "'invalid', 'unavailable', 'failed')",
+            name="ck_telegram_user_action_result",
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "source_update_id",
+            name="uq_telegram_user_action_source_update_id",
+        ),
+    )
+    op.create_index(
+        "ix_telegram_user_action_event_user_id",
+        "telegram_user_action_event",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_telegram_user_action_event_source_update_id",
+        "telegram_user_action_event",
+        ["source_update_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_telegram_user_action_event_action",
+        "telegram_user_action_event",
+        ["action"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_telegram_user_action_event_result",
+        "telegram_user_action_event",
+        ["result"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_telegram_user_action_event_occurred_at",
+        "telegram_user_action_event",
+        ["occurred_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_telegram_user_action_user_occurred",
+        "telegram_user_action_event",
+        ["user_id", "occurred_at", "id"],
+        unique=False,
+    )
+    _install_immutability_guard()
+
+
+def downgrade() -> None:
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute(
+            "DROP TRIGGER IF EXISTS trg_telegram_user_action_no_truncate "
+            "ON telegram_user_action_event"
+        )
+        op.execute(
+            "DROP TRIGGER IF EXISTS trg_telegram_user_action_immutable "
+            "ON telegram_user_action_event"
+        )
+        op.execute("DROP FUNCTION IF EXISTS vpn_reject_telegram_user_action_mutation()")
+    op.drop_index(
+        "ix_telegram_user_action_user_occurred",
+        table_name="telegram_user_action_event",
+    )
+    op.drop_index(
+        "ix_telegram_user_action_event_occurred_at",
+        table_name="telegram_user_action_event",
+    )
+    op.drop_index(
+        "ix_telegram_user_action_event_result",
+        table_name="telegram_user_action_event",
+    )
+    op.drop_index(
+        "ix_telegram_user_action_event_action",
+        table_name="telegram_user_action_event",
+    )
+    op.drop_index(
+        "ix_telegram_user_action_event_source_update_id",
+        table_name="telegram_user_action_event",
+    )
+    op.drop_index(
+        "ix_telegram_user_action_event_user_id",
+        table_name="telegram_user_action_event",
+    )
+    op.drop_table("telegram_user_action_event")

--- a/bot/handlers/balance_history.py
+++ b/bot/handlers/balance_history.py
@@ -6,7 +6,11 @@ from aiogram import F
 from aiogram.types import CallbackQuery, Message
 
 from core.db.unit_of_work import uow
-from core.services import AccountingService, BalanceHistoryPage
+from core.services import (
+    AccountingService,
+    BalanceHistoryPage,
+    TelegramActionAuditContext,
+)
 
 from ..keyboards import balance_actions_keyboard, balance_history_keyboard
 from ..ui import format_money, safe_callback_answer, safe_edit_text
@@ -98,13 +102,22 @@ async def _history_for_telegram_user(
     )
 
 
-async def cmd_balance_history(message: Message) -> None:
+async def cmd_balance_history(
+    message: Message,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     page = await _history_for_telegram_user(
         message.from_user.id,
         message.from_user.username,
         offset=0,
     )
     if page is None:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "finance.balance_history",
+                result="unavailable",
+                metadata={"reason_code": "account_unavailable"},
+            )
         return
     await message.answer(
         render_balance_history(page),
@@ -116,10 +129,15 @@ async def cmd_balance_history(message: Message) -> None:
             direction=None,
         ),
     )
+    if telegram_action_audit is not None:
+        telegram_action_audit.record("finance.balance_history")
 
 
 @router.callback_query(F.data.startswith("balance_history:"))
-async def balance_history_callback(callback: CallbackQuery) -> None:
+async def balance_history_callback(
+    callback: CallbackQuery,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     raw_cursor = callback.data.partition(":")[2]
     try:
         cursor_parts = raw_cursor.split(":")
@@ -143,6 +161,12 @@ async def balance_history_callback(callback: CallbackQuery) -> None:
             raise ValueError
     except ValueError:
         await safe_callback_answer(callback, "Не удалось открыть эту страницу.")
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "finance.balance_history",
+                result="invalid",
+                metadata={"reason_code": "invalid_cursor"},
+            )
         return
 
     page = await _history_for_telegram_user(
@@ -154,6 +178,15 @@ async def balance_history_callback(callback: CallbackQuery) -> None:
     )
     if page is None:
         await safe_callback_answer(callback)
+        if telegram_action_audit is not None:
+            metadata: dict[str, object] = {"reason_code": "account_unavailable"}
+            if direction is not None:
+                metadata["direction"] = direction
+            telegram_action_audit.record(
+                "finance.balance_history",
+                result="unavailable",
+                metadata=metadata,
+            )
         return
     await safe_edit_text(
         callback.message,
@@ -167,10 +200,18 @@ async def balance_history_callback(callback: CallbackQuery) -> None:
         ),
     )
     await safe_callback_answer(callback)
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "finance.balance_history",
+            metadata={"direction": direction} if direction is not None else None,
+        )
 
 
 @router.callback_query(F.data == "balance_summary")
-async def balance_summary_callback(callback: CallbackQuery) -> None:
+async def balance_summary_callback(
+    callback: CallbackQuery,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     from .common import render_balance_summary
 
     user = await get_or_create_user(
@@ -179,6 +220,12 @@ async def balance_summary_callback(callback: CallbackQuery) -> None:
     )
     if user is None:
         await safe_callback_answer(callback)
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "finance.balance_view",
+                result="unavailable",
+                metadata={"reason_code": "account_unavailable"},
+            )
         return
     await safe_edit_text(
         callback.message,
@@ -186,3 +233,5 @@ async def balance_summary_callback(callback: CallbackQuery) -> None:
         reply_markup=balance_actions_keyboard(),
     )
     await safe_callback_answer(callback)
+    if telegram_action_audit is not None:
+        telegram_action_audit.record("finance.balance_view")

--- a/bot/handlers/common.py
+++ b/bot/handlers/common.py
@@ -5,6 +5,7 @@ from aiogram.filters import CommandObject
 from aiogram.types import CallbackQuery, Message
 
 from core.config import settings
+from core.services import TelegramActionAuditContext
 
 from ..instructions import GUIDE_MENU_TEXT, GUIDES
 from ..keyboards import (
@@ -22,6 +23,7 @@ __all__ = ["cmd_start", "cmd_help", "cmd_how_to_use", "cmd_balance"]
 async def cmd_start(
     message: Message,
     command: CommandObject | None = None,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
 ) -> None:
     ref_id = command.args if command and command.args else None
     user = await get_or_create_user(
@@ -30,6 +32,14 @@ async def cmd_start(
         ref_id=ref_id,
     )
     if user is None:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "navigation.start",
+                result="rejected" if ref_id else "unavailable",
+                metadata={
+                    "reason_code": "invalid_invite" if ref_id else "account_unavailable"
+                },
+            )
         return
     await message.answer(
         "👋 <b>Добро пожаловать!</b>\n\n"
@@ -43,9 +53,14 @@ async def cmd_start(
         "Выберите нужный раздел на клавиатуре 👇",
         reply_markup=main_menu_keyboard(),
     )
+    if telegram_action_audit is not None:
+        telegram_action_audit.record("navigation.start")
 
 
-async def cmd_help(message: Message) -> None:
+async def cmd_help(
+    message: Message,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await message.answer(
         "❓ <b>Помощь</b>\n\n"
         "Все основные действия доступны на клавиатуре внизу экрана.\n\n"
@@ -58,18 +73,28 @@ async def cmd_help(message: Message) -> None:
         reply_markup=main_menu_keyboard(),
         disable_web_page_preview=True,
     )
+    if telegram_action_audit is not None:
+        telegram_action_audit.record("navigation.help")
 
 
-async def cmd_how_to_use(message: Message) -> None:
+async def cmd_how_to_use(
+    message: Message,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await message.answer(
         GUIDE_MENU_TEXT,
         reply_markup=guide_menu_keyboard(),
         disable_web_page_preview=True,
     )
+    if telegram_action_audit is not None:
+        telegram_action_audit.record("navigation.instructions_open")
 
 
 @router.callback_query(F.data.startswith("guide:"))
-async def show_guide(callback: CallbackQuery) -> None:
+async def show_guide(
+    callback: CallbackQuery,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     guide = callback.data.partition(":")[2]
     if guide == "menu":
         text = GUIDE_MENU_TEXT
@@ -83,6 +108,12 @@ async def show_guide(callback: CallbackQuery) -> None:
             "Инструкция не найдена. Откройте раздел заново.",
             show_alert=True,
         )
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "navigation.guide_open",
+                result="invalid",
+                metadata={"reason_code": "unknown_guide"},
+            )
         return
 
     await safe_edit_text(
@@ -92,6 +123,11 @@ async def show_guide(callback: CallbackQuery) -> None:
         disable_web_page_preview=True,
     )
     await safe_callback_answer(callback)
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "navigation.guide_open",
+            metadata={"guide": guide},
+        )
 
 
 def render_balance_summary(user) -> str:
@@ -101,14 +137,25 @@ def render_balance_summary(user) -> str:
     return text
 
 
-async def cmd_balance(message: Message) -> None:
+async def cmd_balance(
+    message: Message,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     user = await get_or_create_user(
         message.from_user.id,
         message.from_user.username,
     )
     if user is None:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "finance.balance_view",
+                result="unavailable",
+                metadata={"reason_code": "account_unavailable"},
+            )
         return
     await message.answer(
         render_balance_summary(user),
         reply_markup=balance_actions_keyboard(),
     )
+    if telegram_action_audit is not None:
+        telegram_action_audit.record("finance.balance_view")

--- a/bot/handlers/configs.py
+++ b/bot/handlers/configs.py
@@ -20,6 +20,7 @@ from aiogram.types import (
 from core.config import settings
 from core.domain import VPNOperationStatus, VPNState
 from core.exceptions import APIConnectionError, InsufficientBalanceError, ServiceError
+from core.services.telegram_user_actions import TelegramActionAuditContext
 
 from ..keyboards import cancel_keyboard, main_menu_keyboard
 from ..states import CreateConfig, RenameConfig
@@ -150,12 +151,17 @@ async def _configs_view(
     return text, _configs_markup(configs)
 
 
-async def cmd_configs(message: Message) -> None:
+async def cmd_configs(
+    message: Message,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     text, markup = await _configs_view(
         message.from_user.id,
         message.from_user.username,
     )
     await message.answer(text, reply_markup=markup)
+    if telegram_action_audit is not None:
+        telegram_action_audit.record("vpn.config_list")
 
 
 async def _begin_create_config(
@@ -164,9 +170,16 @@ async def _begin_create_config(
     *,
     tg_id: int,
     username: str | None,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
 ) -> None:
     await get_or_create_user(tg_id, username)
     if settings.maintenance_mode or not settings.provisioning_enabled:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "vpn.config_create_start",
+                result="unavailable",
+                metadata={"reason_code": "provisioning_disabled"},
+            )
         await target.answer(
             "Создание конфигураций временно недоступно. Попробуйте позже.",
             reply_markup=main_menu_keyboard(),
@@ -175,6 +188,12 @@ async def _begin_create_config(
 
     servers = await server_service.list(available_only=True)
     if not servers:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "vpn.config_create_start",
+                result="unavailable",
+                metadata={"reason_code": "no_available_server"},
+            )
         await target.answer(
             "Сейчас нет доступных серверов. Попробуйте позже.",
             reply_markup=main_menu_keyboard(),
@@ -201,31 +220,47 @@ async def _begin_create_config(
         reply_markup=InlineKeyboardMarkup(inline_keyboard=buttons),
     )
     await state.set_state(CreateConfig.choosing_server)
+    if telegram_action_audit is not None:
+        telegram_action_audit.record("vpn.config_create_start")
 
 
-async def cmd_create_config(message: Message, state: FSMContext) -> None:
+async def cmd_create_config(
+    message: Message,
+    state: FSMContext,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await _begin_create_config(
         message,
         state,
         tg_id=message.from_user.id,
         username=message.from_user.username,
+        telegram_action_audit=telegram_action_audit,
     )
 
 
 @router.callback_query(F.data == "cfg:create")
-async def create_config_cb(callback: CallbackQuery, state: FSMContext) -> None:
+async def create_config_cb(
+    callback: CallbackQuery,
+    state: FSMContext,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await state.clear()
     await _begin_create_config(
         callback.message,
         state,
         tg_id=callback.from_user.id,
         username=callback.from_user.username,
+        telegram_action_audit=telegram_action_audit,
     )
     await safe_callback_answer(callback)
 
 
 @router.callback_query(F.data == "cfg:list")
-async def list_configs_cb(callback: CallbackQuery, state: FSMContext) -> None:
+async def list_configs_cb(
+    callback: CallbackQuery,
+    state: FSMContext,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await state.clear()
     text, markup = await _configs_view(
         callback.from_user.id,
@@ -233,6 +268,8 @@ async def list_configs_cb(callback: CallbackQuery, state: FSMContext) -> None:
     )
     await safe_edit_text(callback.message, text, reply_markup=markup)
     await safe_callback_answer(callback)
+    if telegram_action_audit is not None:
+        telegram_action_audit.record("vpn.config_list")
 
 
 async def _callback_id(
@@ -255,12 +292,33 @@ async def _callback_id(
 
 
 @router.callback_query(F.data.startswith("server:"))
-async def choose_server(callback: CallbackQuery, state: FSMContext) -> None:
+async def choose_server(
+    callback: CallbackQuery,
+    state: FSMContext,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     server_id = await _callback_id(callback, "server:")
     if server_id is None:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "vpn.config_server_select",
+                result="invalid",
+                metadata={"reason_code": "invalid_callback"},
+            )
         return
     server = await server_service.get(server_id)
     if server is None or not await server_service.accepts_new_config(server_id):
+        if telegram_action_audit is not None:
+            metadata: dict[str, object] = {
+                "reason_code": "server_unavailable",
+            }
+            if server is not None:
+                metadata["server_id"] = server_id
+            telegram_action_audit.record(
+                "vpn.config_server_select",
+                result="unavailable",
+                metadata=metadata,
+            )
         await safe_callback_answer(
             callback,
             "Сервер больше недоступен. Выберите другой.",
@@ -277,15 +335,29 @@ async def choose_server(callback: CallbackQuery, state: FSMContext) -> None:
     )
     await state.set_state(CreateConfig.entering_name)
     await safe_callback_answer(callback)
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "vpn.config_server_select",
+            metadata={"server_id": server_id},
+        )
 
 
 @router.message(CreateConfig.choosing_server, ~F.successful_payment)
-async def choose_server_message_hint(message: Message) -> None:
+async def choose_server_message_hint(
+    message: Message,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await message.answer(
         "Выберите сервер кнопкой в сообщении выше. Чтобы выйти, откройте "
         "другой раздел в меню.",
         reply_markup=main_menu_keyboard(),
     )
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "vpn.config_server_select",
+            result="invalid",
+            metadata={"reason_code": "button_required"},
+        )
 
 
 @router.message(CreateConfig.entering_name, F.text, ~F.successful_payment)
@@ -294,10 +366,17 @@ async def got_name(
     state: FSMContext,
     bot: Any,
     event_update: Update,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
 ) -> None:
     data = await state.get_data()
     server_id = data.get("server_id")
     if not server_id:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "vpn.config_create_submit",
+                result="rejected",
+                metadata={"reason_code": "server_not_selected"},
+            )
         await message.answer(
             "Сервер не выбран. Начните создание заново.",
             reply_markup=main_menu_keyboard(),
@@ -307,6 +386,12 @@ async def got_name(
 
     display_name = (message.text or "").strip()
     user = await get_or_create_user(message.from_user.id, message.from_user.username)
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "vpn.config_create_submit",
+            result="handled",
+            metadata={"server_id": server_id},
+        )
     purchase_key = f"telegram:create-config:update:{event_update.update_id}"
     unique_name = uuid5(NAMESPACE_URL, purchase_key).hex
     try:
@@ -319,6 +404,15 @@ async def got_name(
             idempotency_key=purchase_key,
         )
     except InsufficientBalanceError:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "vpn.config_create_submit",
+                result="rejected",
+                metadata={
+                    "server_id": server_id,
+                    "reason_code": "insufficient_balance",
+                },
+            )
         await message.answer(
             "Недостаточно средств. Сначала пополните баланс.",
             reply_markup=main_menu_keyboard(),
@@ -330,6 +424,15 @@ async def got_name(
         # retry this exact update without charging or provisioning twice.
         raise
     except ServiceError:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "vpn.config_create_submit",
+                result="rejected",
+                metadata={
+                    "server_id": server_id,
+                    "reason_code": "request_rejected",
+                },
+            )
         await message.answer(
             "Не удалось создать конфигурацию. Проверьте название и попробуйте "
             "ещё раз позже.",
@@ -360,23 +463,49 @@ async def got_name(
         "Откройте <b>«Инструкции»</b>, если подключаете устройство впервые.",
         reply_markup=main_menu_keyboard(),
     )
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "vpn.config_create_submit",
+            metadata={
+                "config_id": config.id,
+                "server_id": server_id,
+            },
+        )
     await state.clear()
 
 
 @router.message(CreateConfig.entering_name, ~F.successful_payment)
-async def config_name_message_hint(message: Message) -> None:
+async def config_name_message_hint(
+    message: Message,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await message.answer(
         "Название нужно отправить текстом, например «Мой телефон».",
         reply_markup=cancel_keyboard(),
     )
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "vpn.config_create_submit",
+            result="invalid",
+            metadata={"reason_code": "text_required"},
+        )
 
 
 async def _owned_config(
     callback: CallbackQuery,
     prefix: str,
+    *,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+    audit_action: str,
 ) -> tuple[Any, Any] | None:
     config_id = await _callback_id(callback, prefix)
     if config_id is None:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                audit_action,
+                result="invalid",
+                metadata={"reason_code": "invalid_callback"},
+            )
         return None
     user = await get_or_create_user(
         callback.from_user.id,
@@ -384,6 +513,15 @@ async def _owned_config(
     )
     config = await config_service.get(config_id)
     if not config or config.owner_id != user.id:
+        if telegram_action_audit is not None:
+            # Never persist the attacker-controlled target before ownership is
+            # proven. The public response deliberately has the same shape for
+            # a missing and a foreign configuration.
+            telegram_action_audit.record(
+                audit_action,
+                result="rejected",
+                metadata={"reason_code": "config_not_found"},
+            )
         await safe_callback_answer(
             callback,
             "Конфигурация не найдена.",
@@ -473,21 +611,52 @@ async def _config_details(config: Any) -> tuple[str, InlineKeyboardMarkup]:
 
 
 @router.callback_query(F.data.startswith("cfg:"))
-async def show_config(callback: CallbackQuery) -> None:
-    owned = await _owned_config(callback, "cfg:")
+async def show_config(
+    callback: CallbackQuery,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
+    owned = await _owned_config(
+        callback,
+        "cfg:",
+        telegram_action_audit=telegram_action_audit,
+        audit_action="vpn.config_view",
+    )
     if owned is None:
         return
     config, _ = owned
     text, markup = await _config_details(config)
     await safe_edit_text(callback.message, text, reply_markup=markup)
     await safe_callback_answer(callback)
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "vpn.config_view",
+            metadata={"config_id": config.id},
+        )
 
 
 @router.callback_query(F.data.startswith("sus:"))
-async def suspend_config_cb(callback: CallbackQuery) -> None:
-    owned = await _owned_config(callback, "sus:")
+async def suspend_config_cb(
+    callback: CallbackQuery,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
+    owned = await _owned_config(
+        callback,
+        "sus:",
+        telegram_action_audit=telegram_action_audit,
+        audit_action="vpn.config_suspend",
+    )
     if owned is None:
         return
+    config, _ = owned
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "vpn.config_suspend",
+            result="unavailable",
+            metadata={
+                "config_id": config.id,
+                "reason_code": "manual_pause_disabled",
+            },
+        )
     await safe_callback_answer(
         callback,
         "Ручная пауза временно недоступна. Для потерянного устройства удалите "
@@ -497,10 +666,28 @@ async def suspend_config_cb(callback: CallbackQuery) -> None:
 
 
 @router.callback_query(F.data.startswith("uns:"))
-async def unsuspend_config_cb(callback: CallbackQuery) -> None:
-    owned = await _owned_config(callback, "uns:")
+async def unsuspend_config_cb(
+    callback: CallbackQuery,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
+    owned = await _owned_config(
+        callback,
+        "uns:",
+        telegram_action_audit=telegram_action_audit,
+        audit_action="vpn.config_resume",
+    )
     if owned is None:
         return
+    config, _ = owned
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "vpn.config_resume",
+            result="unavailable",
+            metadata={
+                "config_id": config.id,
+                "reason_code": "manual_resume_disabled",
+            },
+        )
     await safe_callback_answer(
         callback,
         "Ручное возобновление временно недоступно. Конфигурации, остановленные "
@@ -510,8 +697,16 @@ async def unsuspend_config_cb(callback: CallbackQuery) -> None:
 
 
 @router.callback_query(F.data.startswith("del:"))
-async def delete_config_cb(callback: CallbackQuery) -> None:
-    owned = await _owned_config(callback, "del:")
+async def delete_config_cb(
+    callback: CallbackQuery,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
+    owned = await _owned_config(
+        callback,
+        "del:",
+        telegram_action_audit=telegram_action_audit,
+        audit_action="vpn.config_delete_request",
+    )
     if owned is None:
         return
     config, _ = owned
@@ -534,17 +729,39 @@ async def delete_config_cb(callback: CallbackQuery) -> None:
         reply_markup=markup,
     )
     await safe_callback_answer(callback)
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "vpn.config_delete_request",
+            metadata={"config_id": config.id},
+        )
 
 
 @router.callback_query(F.data.startswith("del_ok:"))
-async def confirm_delete_config_cb(callback: CallbackQuery) -> None:
-    owned = await _owned_config(callback, "del_ok:")
+async def confirm_delete_config_cb(
+    callback: CallbackQuery,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
+    owned = await _owned_config(
+        callback,
+        "del_ok:",
+        telegram_action_audit=telegram_action_audit,
+        audit_action="vpn.config_delete_confirm",
+    )
     if owned is None:
         return
     config, _ = owned
     try:
         await config_service.revoke_config(config.id)
     except ServiceError:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "vpn.config_delete_confirm",
+                result="failed",
+                metadata={
+                    "config_id": config.id,
+                    "reason_code": "vpn_operation_failed",
+                },
+            )
         await callback.message.answer("Не удалось удалить конфигурацию.")
         await safe_callback_answer(callback)
         return
@@ -559,17 +776,46 @@ async def confirm_delete_config_cb(callback: CallbackQuery) -> None:
         reply_markup=markup,
     )
     await safe_callback_answer(callback)
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "vpn.config_delete_confirm",
+            metadata={"config_id": config.id},
+        )
 
 
 @router.callback_query(F.data.startswith("dl:"))
-async def download_config_cb(callback: CallbackQuery, bot: Any) -> None:
-    owned = await _owned_config(callback, "dl:")
+async def download_config_cb(
+    callback: CallbackQuery,
+    bot: Any,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
+    owned = await _owned_config(
+        callback,
+        "dl:",
+        telegram_action_audit=telegram_action_audit,
+        audit_action="vpn.config_download",
+    )
     if owned is None:
         return
     config, _ = owned
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "vpn.config_download",
+            result="handled",
+            metadata={"config_id": config.id},
+        )
     try:
         content = await config_service.download_config(config.id)
     except ServiceError:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "vpn.config_download",
+                result="failed",
+                metadata={
+                    "config_id": config.id,
+                    "reason_code": "download_failed",
+                },
+            )
         await callback.message.answer("Не удалось скачать конфигурацию.")
         await safe_callback_answer(callback)
         return
@@ -591,11 +837,25 @@ async def download_config_cb(callback: CallbackQuery, bot: Any) -> None:
         except OSError:
             pass
     await safe_callback_answer(callback)
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "vpn.config_download",
+            metadata={"config_id": config.id},
+        )
 
 
 @router.callback_query(F.data.startswith("rn:"))
-async def rename_config_cb(callback: CallbackQuery, state: FSMContext) -> None:
-    owned = await _owned_config(callback, "rn:")
+async def rename_config_cb(
+    callback: CallbackQuery,
+    state: FSMContext,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
+    owned = await _owned_config(
+        callback,
+        "rn:",
+        telegram_action_audit=telegram_action_audit,
+        audit_action="vpn.config_rename_start",
+    )
     if owned is None:
         return
     config, _ = owned
@@ -606,13 +866,28 @@ async def rename_config_cb(callback: CallbackQuery, state: FSMContext) -> None:
     )
     await state.set_state(RenameConfig.entering_name)
     await safe_callback_answer(callback)
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "vpn.config_rename_start",
+            metadata={"config_id": config.id},
+        )
 
 
 @router.message(RenameConfig.entering_name, F.text, ~F.successful_payment)
-async def got_new_name(message: Message, state: FSMContext) -> None:
+async def got_new_name(
+    message: Message,
+    state: FSMContext,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     data = await state.get_data()
     config_id = data.get("config_id")
     if not config_id:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "vpn.config_rename_submit",
+                result="rejected",
+                metadata={"reason_code": "config_not_selected"},
+            )
         await message.answer(
             "Конфигурация не выбрана. Начните заново.",
             reply_markup=main_menu_keyboard(),
@@ -623,19 +898,45 @@ async def got_new_name(message: Message, state: FSMContext) -> None:
     user = await get_or_create_user(message.from_user.id, message.from_user.username)
     config = await config_service.get(config_id)
     if not config or config.owner_id != user.id:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "vpn.config_rename_submit",
+                result="rejected",
+                metadata={"reason_code": "config_not_found"},
+            )
         await message.answer(
             "Конфигурация не найдена.",
             reply_markup=main_menu_keyboard(),
         )
         await state.clear()
         return
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "vpn.config_rename_submit",
+            result="handled",
+            metadata={"config_id": config.id},
+        )
     try:
         await config_service.rename_config(config_id, message.text or "")
         await message.answer(
             "✅ Конфигурация переименована.",
             reply_markup=main_menu_keyboard(),
         )
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "vpn.config_rename_submit",
+                metadata={"config_id": config.id},
+            )
     except ServiceError:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "vpn.config_rename_submit",
+                result="invalid",
+                metadata={
+                    "config_id": config.id,
+                    "reason_code": "invalid_name",
+                },
+            )
         await message.answer(
             "Не удалось переименовать конфигурацию. Название должно содержать "
             "от 1 до 128 символов.",
@@ -645,8 +946,17 @@ async def got_new_name(message: Message, state: FSMContext) -> None:
 
 
 @router.message(RenameConfig.entering_name, ~F.successful_payment)
-async def rename_message_hint(message: Message) -> None:
+async def rename_message_hint(
+    message: Message,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await message.answer(
         "Новое название нужно отправить текстом.",
         reply_markup=cancel_keyboard(),
     )
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "vpn.config_rename_submit",
+            result="invalid",
+            metadata={"reason_code": "text_required"},
+        )

--- a/bot/handlers/fallback.py
+++ b/bot/handlers/fallback.py
@@ -2,14 +2,28 @@ from aiogram import F, Router
 from aiogram.filters import StateFilter
 from aiogram.types import Message
 
+from core.services import TelegramActionAuditContext
+
 from ..keyboards import main_menu_keyboard
 
 
-async def unknown_text(message: Message) -> None:
+async def unknown_text(
+    message: Message,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await message.answer(
         "Не понял сообщение. Выберите действие на клавиатуре 👇",
         reply_markup=main_menu_keyboard(),
     )
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "message.unrecognized",
+            result="invalid",
+            metadata={
+                "content_type": "text",
+                "reason_code": "unsupported_input",
+            },
+        )
 
 
 def register(router: Router) -> None:

--- a/bot/handlers/navigation.py
+++ b/bot/handlers/navigation.py
@@ -6,6 +6,8 @@ from aiogram.filters import Command, CommandObject
 from aiogram.fsm.context import FSMContext
 from aiogram.types import Message
 
+from core.services import TelegramActionAuditContext
+
 from ..keyboards import (
     MENU_BALANCE,
     MENU_CANCEL,
@@ -15,6 +17,7 @@ from ..keyboards import (
     MENU_TOP_UP,
     main_menu_keyboard,
 )
+from ..states import CreateConfig, RenameConfig
 
 router = Router(name="telegram-navigation")
 router.message.filter(F.chat.type == ChatType.PRIVATE)
@@ -24,101 +27,187 @@ async def _reset_state(state: FSMContext) -> None:
     await state.clear()
 
 
+def _safe_flow_name(state_name: str | None) -> str:
+    if state_name in {item.state for item in CreateConfig.__all_states__}:
+        return "create_config"
+    if state_name in {item.state for item in RenameConfig.__all_states__}:
+        return "rename_config"
+    return "none"
+
+
 @router.message(Command("start"))
 async def start_navigation(
     message: Message,
     state: FSMContext,
     command: CommandObject | None = None,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
 ) -> None:
     await _reset_state(state)
     from .common import cmd_start
 
-    await cmd_start(message, command)
+    await cmd_start(
+        message,
+        command,
+        telegram_action_audit=telegram_action_audit,
+    )
 
 
 @router.message(Command("menu"))
-async def menu_navigation(message: Message, state: FSMContext) -> None:
+async def menu_navigation(
+    message: Message,
+    state: FSMContext,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await _reset_state(state)
     await message.answer(
         "Выберите нужный раздел 👇",
         reply_markup=main_menu_keyboard(),
     )
+    if telegram_action_audit is not None:
+        telegram_action_audit.record("navigation.menu")
 
 
 @router.message(Command("help"))
-async def help_navigation(message: Message, state: FSMContext) -> None:
+async def help_navigation(
+    message: Message,
+    state: FSMContext,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await _reset_state(state)
     from .common import cmd_help
 
-    await cmd_help(message)
+    await cmd_help(
+        message,
+        telegram_action_audit=telegram_action_audit,
+    )
 
 
 @router.message(Command("balance"))
 @router.message(F.text == MENU_BALANCE)
-async def balance_navigation(message: Message, state: FSMContext) -> None:
+async def balance_navigation(
+    message: Message,
+    state: FSMContext,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await _reset_state(state)
     from .common import cmd_balance
 
-    await cmd_balance(message)
+    await cmd_balance(
+        message,
+        telegram_action_audit=telegram_action_audit,
+    )
 
 
 @router.message(Command("history"))
-async def balance_history_navigation(message: Message, state: FSMContext) -> None:
+async def balance_history_navigation(
+    message: Message,
+    state: FSMContext,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await _reset_state(state)
     from .balance_history import cmd_balance_history
 
-    await cmd_balance_history(message)
+    await cmd_balance_history(
+        message,
+        telegram_action_audit=telegram_action_audit,
+    )
 
 
 @router.message(Command("configs"))
 @router.message(F.text == MENU_CONFIGS)
-async def configs_navigation(message: Message, state: FSMContext) -> None:
+async def configs_navigation(
+    message: Message,
+    state: FSMContext,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await _reset_state(state)
     from .configs import cmd_configs
 
-    await cmd_configs(message)
+    await cmd_configs(
+        message,
+        telegram_action_audit=telegram_action_audit,
+    )
 
 
 @router.message(Command("topup"))
 @router.message(F.text == MENU_TOP_UP)
-async def top_up_navigation(message: Message, state: FSMContext) -> None:
+async def top_up_navigation(
+    message: Message,
+    state: FSMContext,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await _reset_state(state)
     from .payments import cmd_topup
 
-    await cmd_topup(message)
+    await cmd_topup(
+        message,
+        telegram_action_audit=telegram_action_audit,
+    )
 
 
 @router.message(Command("how_to_use"))
 @router.message(F.text == MENU_INSTRUCTIONS)
-async def instructions_navigation(message: Message, state: FSMContext) -> None:
+async def instructions_navigation(
+    message: Message,
+    state: FSMContext,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await _reset_state(state)
     from .common import cmd_how_to_use
 
-    await cmd_how_to_use(message)
+    await cmd_how_to_use(
+        message,
+        telegram_action_audit=telegram_action_audit,
+    )
 
 
 @router.message(Command("referrals"))
 @router.message(F.text == MENU_REFERRALS)
-async def referrals_navigation(message: Message, state: FSMContext) -> None:
+async def referrals_navigation(
+    message: Message,
+    state: FSMContext,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await _reset_state(state)
     from .referrals import cmd_referrals
 
-    await cmd_referrals(message)
+    await cmd_referrals(
+        message,
+        telegram_action_audit=telegram_action_audit,
+    )
 
 
 @router.message(Command("create_config"))
-async def create_config_navigation(message: Message, state: FSMContext) -> None:
+async def create_config_navigation(
+    message: Message,
+    state: FSMContext,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await _reset_state(state)
     from .configs import cmd_create_config
 
-    await cmd_create_config(message, state)
+    await cmd_create_config(
+        message,
+        state,
+        telegram_action_audit=telegram_action_audit,
+    )
 
 
 @router.message(Command("cancel"))
 @router.message(F.text == MENU_CANCEL)
-async def cancel_navigation(message: Message, state: FSMContext) -> None:
+async def cancel_navigation(
+    message: Message,
+    state: FSMContext,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
+    flow = _safe_flow_name(await state.get_state())
     await _reset_state(state)
     await message.answer(
         "Действие отменено.",
         reply_markup=main_menu_keyboard(),
     )
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "navigation.cancel",
+            metadata={"flow": flow},
+        )

--- a/bot/handlers/payments.py
+++ b/bot/handlers/payments.py
@@ -18,6 +18,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from core.config import settings
 from core.exceptions import InvalidOperationError, UserNotFoundError
 from core.services import TelegramPayService
+from core.services.telegram_user_actions import TelegramActionAuditContext
 
 from ..keyboards import main_menu_keyboard
 from ..ui import format_money, safe_callback_answer
@@ -54,8 +55,17 @@ def _top_up_keyboard() -> InlineKeyboardMarkup:
     )
 
 
-async def cmd_topup(message: Message) -> None:
+async def cmd_topup(
+    message: Message,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     if not settings.payments_enabled:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "finance.topup_open",
+                result="unavailable",
+                metadata={"reason_code": "payments_disabled"},
+            )
         await message.answer(
             PAYMENTS_DISABLED_TEXT,
             reply_markup=main_menu_keyboard(),
@@ -69,19 +79,45 @@ async def cmd_topup(message: Message) -> None:
         "передаст его платёжному провайдеру:",
         reply_markup=_top_up_keyboard(),
     )
+    if telegram_action_audit is not None:
+        telegram_action_audit.record("finance.topup_open")
 
 
 @router.callback_query(lambda c: c.data == "pay:crypto")
-async def pay_crypto(callback: CallbackQuery) -> None:
+async def pay_crypto(
+    callback: CallbackQuery,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await callback.message.answer(
         "Оплата криптовалютой пока недоступна. Выберите оплату через Telegram."
     )
     await safe_callback_answer(callback)
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "finance.payment_provider_select",
+            result="unavailable",
+            metadata={
+                "provider": "crypto",
+                "reason_code": "provider_unavailable",
+            },
+        )
 
 
 @router.callback_query(lambda c: c.data == "pay:telegram")
-async def pay_telegram(callback: CallbackQuery) -> None:
+async def pay_telegram(
+    callback: CallbackQuery,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     if not settings.payments_enabled:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "finance.payment_provider_select",
+                result="unavailable",
+                metadata={
+                    "provider": "telegram",
+                    "reason_code": "payments_disabled",
+                },
+            )
         await safe_callback_answer(
             callback,
             PAYMENTS_DISABLED_TEXT,
@@ -93,11 +129,27 @@ async def pay_telegram(callback: CallbackQuery) -> None:
         reply_markup=_top_up_keyboard(),
     )
     await safe_callback_answer(callback)
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "finance.payment_provider_select",
+            metadata={"provider": "telegram"},
+        )
 
 
 @router.callback_query(F.data.startswith("topup:"))
-async def got_topup_amount(callback: CallbackQuery, bot, event_update: Update) -> None:
+async def got_topup_amount(
+    callback: CallbackQuery,
+    bot,
+    event_update: Update,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     if not settings.payments_enabled:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "finance.payment_amount_select",
+                result="unavailable",
+                metadata={"reason_code": "payments_disabled"},
+            )
         await safe_callback_answer(
             callback,
             PAYMENTS_DISABLED_TEXT,
@@ -110,12 +162,26 @@ async def got_topup_amount(callback: CallbackQuery, bot, event_update: Update) -
         if amount not in allowed_amounts:
             raise ValueError
     except (DecimalInvalidOperation, IndexError, ValueError):
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "finance.payment_amount_select",
+                result="invalid",
+                metadata={"reason_code": "invalid_amount"},
+            )
         await safe_callback_answer(
             callback,
             "Некорректная сумма.",
             show_alert=True,
         )
         return
+
+    amount_rub = int(amount)
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "finance.payment_amount_select",
+            result="handled",
+            metadata={"amount_rub": amount_rub},
+        )
 
     user = await get_or_create_user(callback.from_user.id, callback.from_user.username)
     intent = await billing_service.create_payment_intent(
@@ -131,6 +197,14 @@ async def got_topup_amount(callback: CallbackQuery, bot, event_update: Update) -
         provider="telegram",
     )
     if not claimed:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "finance.payment_amount_select",
+                metadata={
+                    "amount_rub": amount_rub,
+                    "reason_code": "invoice_already_claimed",
+                },
+            )
         await safe_callback_answer(
             callback,
             "Счёт для этого запроса уже создан. Если он не появился, "
@@ -148,6 +222,15 @@ async def got_topup_amount(callback: CallbackQuery, bot, event_update: Update) -
             currency=intent.currency,
         )
     except InvalidOperationError:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "finance.payment_amount_select",
+                result="unavailable",
+                metadata={
+                    "amount_rub": amount_rub,
+                    "reason_code": "payments_disabled",
+                },
+            )
         await safe_callback_answer(
             callback,
             PAYMENTS_DISABLED_TEXT,
@@ -155,6 +238,15 @@ async def got_topup_amount(callback: CallbackQuery, bot, event_update: Update) -
         )
         return
     except TelegramAPIError:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "finance.payment_amount_select",
+                result="failed",
+                metadata={
+                    "amount_rub": amount_rub,
+                    "reason_code": "invoice_delivery_ambiguous",
+                },
+            )
         logger.warning(
             "Telegram invoice delivery failed after its attempt was claimed",
             extra={"intent_id": intent.intent_id, "user_id": user.id},
@@ -173,11 +265,26 @@ async def got_topup_amount(callback: CallbackQuery, bot, event_update: Update) -
             pass
         return
     await safe_callback_answer(callback)
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "finance.payment_amount_select",
+            metadata={"amount_rub": amount_rub},
+        )
 
 
 @payment_events_router.pre_checkout_query()
-async def process_pre_checkout_query(pcq: PreCheckoutQuery, bot) -> None:
+async def process_pre_checkout_query(
+    pcq: PreCheckoutQuery,
+    bot,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     if not settings.payments_enabled:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "finance.payment_pre_checkout",
+                result="unavailable",
+                metadata={"reason_code": "payments_disabled"},
+            )
         await bot.answer_pre_checkout_query(
             pcq.id,
             ok=False,
@@ -197,6 +304,12 @@ async def process_pre_checkout_query(pcq: PreCheckoutQuery, bot) -> None:
             provider="telegram",
         )
     except Exception:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "finance.payment_pre_checkout",
+                result="rejected",
+                metadata={"reason_code": "payment_validation_failed"},
+            )
         await bot.answer_pre_checkout_query(
             pcq.id,
             ok=False,
@@ -204,10 +317,16 @@ async def process_pre_checkout_query(pcq: PreCheckoutQuery, bot) -> None:
         )
         return
     await bot.answer_pre_checkout_query(pcq.id, ok=True)
+    if telegram_action_audit is not None:
+        telegram_action_audit.record("finance.payment_pre_checkout")
 
 
 @payment_events_router.message(F.successful_payment)
-async def successful_payment_handler(message: Message, bot) -> None:
+async def successful_payment_handler(
+    message: Message,
+    bot,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     payment = message.successful_payment
     qty = Decimal(payment.total_amount) / Decimal(100)
     intent_id = (
@@ -215,6 +334,7 @@ async def successful_payment_handler(message: Message, bot) -> None:
         if payment.invoice_payload.startswith("topup:")
         else None
     )
+    receipt = None
     for attempt in range(1, 6):
         try:
             user = await get_or_create_user(
@@ -225,7 +345,7 @@ async def successful_payment_handler(message: Message, bot) -> None:
                 raise UserNotFoundError(
                     "Captured Telegram payment belongs to an unknown account"
                 )
-            await billing_service.record_telegram_payment(
+            receipt = await billing_service.record_telegram_payment(
                 user_id=user.id,
                 telegram_payment_charge_id=payment.telegram_payment_charge_id,
                 provider_payment_charge_id=payment.provider_payment_charge_id,
@@ -252,6 +372,17 @@ async def successful_payment_handler(message: Message, bot) -> None:
                 )
                 raise
             await asyncio.sleep(2 ** (attempt - 1))
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "finance.payment_successful",
+            metadata={
+                "reason_code": (
+                    "payment_credited"
+                    if getattr(receipt, "credited", True)
+                    else "payment_replayed"
+                )
+            },
+        )
     try:
         await bot.send_message(
             chat_id=message.from_user.id,

--- a/bot/handlers/privacy.py
+++ b/bot/handlers/privacy.py
@@ -2,23 +2,43 @@ from aiogram import F, Router
 from aiogram.enums import ChatType
 from aiogram.types import CallbackQuery, Message
 
+from core.services import TelegramActionAuditContext
+
 from ..ui import safe_callback_answer
 
 router = Router(name="telegram-private-chat-boundary")
 
 
 @router.message(F.chat.type.in_({ChatType.GROUP, ChatType.SUPERGROUP}))
-async def group_message(message: Message) -> None:
+async def group_message(
+    message: Message,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await message.answer(
         "🔐 Из соображений безопасности баланс и VPN-конфигурации доступны "
         "только в личном чате. Откройте профиль бота и нажмите «Начать»."
     )
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "privacy.non_private_input",
+            result="rejected",
+            metadata={"reason_code": "private_chat_required"},
+        )
 
 
 @router.callback_query(F.message.chat.type.in_({ChatType.GROUP, ChatType.SUPERGROUP}))
-async def group_callback(callback: CallbackQuery) -> None:
+async def group_callback(
+    callback: CallbackQuery,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     await safe_callback_answer(
         callback,
         "Откройте бота в личном чате.",
         show_alert=True,
     )
+    if telegram_action_audit is not None:
+        telegram_action_audit.record(
+            "privacy.non_private_input",
+            result="rejected",
+            metadata={"reason_code": "private_chat_required"},
+        )

--- a/bot/handlers/referrals.py
+++ b/bot/handlers/referrals.py
@@ -10,7 +10,11 @@ from aiogram.utils.deep_linking import create_start_link
 
 from core.config import settings
 from core.db.unit_of_work import uow
-from core.services import ReferralOverview, ReferralService
+from core.services import (
+    ReferralOverview,
+    ReferralService,
+    TelegramActionAuditContext,
+)
 
 from ..keyboards import referral_program_keyboard
 from ..ui import format_money, safe_callback_answer, safe_edit_text
@@ -86,13 +90,38 @@ async def _referral_screen(
     )
 
 
-async def cmd_referrals(message: Message, bot: Bot | None = None) -> None:
+def _record_referral_outcome(
+    telegram_action_audit: TelegramActionAuditContext | None,
+) -> None:
+    if telegram_action_audit is None:
+        return
+    if settings.referral_rewards_enabled:
+        telegram_action_audit.record("referral.overview")
+    else:
+        telegram_action_audit.record(
+            "referral.overview",
+            result="unavailable",
+            metadata={"reason_code": "referral_rewards_disabled"},
+        )
+
+
+async def cmd_referrals(
+    message: Message,
+    bot: Bot | None = None,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     screen = await _referral_screen(
         tg_id=message.from_user.id,
         username=message.from_user.username,
         bot=bot or message.bot,
     )
     if screen is None:
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "referral.overview",
+                result="unavailable",
+                metadata={"reason_code": "account_unavailable"},
+            )
         return
     text, markup = screen
     await message.answer(
@@ -100,10 +129,14 @@ async def cmd_referrals(message: Message, bot: Bot | None = None) -> None:
         reply_markup=markup,
         disable_web_page_preview=True,
     )
+    _record_referral_outcome(telegram_action_audit)
 
 
 @router.callback_query(F.data.startswith("refs:"))
-async def legacy_referrals_callback(callback: CallbackQuery) -> None:
+async def legacy_referrals_callback(
+    callback: CallbackQuery,
+    telegram_action_audit: TelegramActionAuditContext | None = None,
+) -> None:
     """Keep already-sent referral buttons useful after the rollout."""
 
     screen = await _referral_screen(
@@ -113,6 +146,12 @@ async def legacy_referrals_callback(callback: CallbackQuery) -> None:
     )
     if screen is None:
         await safe_callback_answer(callback)
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "referral.overview",
+                result="unavailable",
+                metadata={"reason_code": "account_unavailable"},
+            )
         return
     text, markup = screen
     await safe_edit_text(
@@ -122,3 +161,4 @@ async def legacy_referrals_callback(callback: CallbackQuery) -> None:
         disable_web_page_preview=True,
     )
     await safe_callback_answer(callback)
+    _record_referral_outcome(telegram_action_audit)

--- a/bot/middlewares/invite_access.py
+++ b/bot/middlewares/invite_access.py
@@ -10,7 +10,7 @@ from aiogram import BaseMiddleware
 from aiogram.exceptions import TelegramAPIError
 from aiogram.types import CallbackQuery, Message, PreCheckoutQuery, TelegramObject
 
-from core.services import UserService
+from core.services import TelegramActionAuditContext, UserService
 
 # The middleware only lets a syntactically valid private invitation reach the
 # /start handler. The service performs the authoritative database lookup.
@@ -38,6 +38,9 @@ class InviteOnlyAccessMiddleware(BaseMiddleware):
         event: TelegramObject,
         data: dict[str, Any],
     ) -> Any:
+        telegram_action_audit = data.get("telegram_action_audit")
+        if not isinstance(telegram_action_audit, TelegramActionAuditContext):
+            telegram_action_audit = None
         from_user = getattr(event, "from_user", None)
         if from_user is None:
             return await handler(event, data)
@@ -48,6 +51,12 @@ class InviteOnlyAccessMiddleware(BaseMiddleware):
                 reactivate_delivery=self._is_private_inbound(event),
             )
         except Exception:
+            if telegram_action_audit is not None:
+                telegram_action_audit.record(
+                    "access.invite_lookup",
+                    result="unavailable",
+                    metadata={"reason_code": "lookup_failed"},
+                )
             # Database uncertainty must never look like a definitive access
             # denial: regular/captured updates stay retryable in the durable
             # inbox. Pre-checkout is the one protocol event that must receive
@@ -78,12 +87,24 @@ class InviteOnlyAccessMiddleware(BaseMiddleware):
                     ok=False,
                     error_message="Доступ к боту возможен только по приглашению.",
                 )
+            if telegram_action_audit is not None:
+                telegram_action_audit.record(
+                    "access.invite_required",
+                    result="rejected",
+                    metadata={"reason_code": "invite_required"},
+                )
             return None
 
         if isinstance(event, CallbackQuery):
             # Close the client-side spinner without disclosing account state.
             with contextlib.suppress(TelegramAPIError):
                 await event.answer()
+            if telegram_action_audit is not None:
+                telegram_action_audit.record(
+                    "access.invite_required",
+                    result="rejected",
+                    metadata={"reason_code": "invite_required"},
+                )
             return None
 
         if isinstance(event, Message):
@@ -93,8 +114,20 @@ class InviteOnlyAccessMiddleware(BaseMiddleware):
                 return await handler(event, data)
             if self._is_private_invited_start(event):
                 return await handler(event, data)
+            if telegram_action_audit is not None:
+                telegram_action_audit.record(
+                    "access.invite_required",
+                    result="rejected",
+                    metadata={"reason_code": "invite_required"},
+                )
             return None
 
+        if telegram_action_audit is not None:
+            telegram_action_audit.record(
+                "access.invite_required",
+                result="rejected",
+                metadata={"reason_code": "invite_required"},
+            )
         return None
 
     @staticmethod

--- a/bot/update_ingress.py
+++ b/bot/update_ingress.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 import logging
 import time
 
@@ -13,6 +14,7 @@ from core.services.telegram_updates import (
     ClaimedTelegramUpdate,
     TelegramUpdateService,
 )
+from core.services.telegram_user_actions import TelegramActionAuditContext
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +99,8 @@ class TelegramUpdateProcessor:
         if claimed is None:
             return False
 
-        handler = asyncio.create_task(self._dispatch(claimed))
+        audit_context = TelegramActionAuditContext.from_payload(claimed.payload)
+        handler = asyncio.create_task(self._dispatch(claimed, audit_context))
         heartbeat = asyncio.create_task(self._renew_lease(claimed))
         try:
             done, _ = await asyncio.wait(
@@ -112,7 +115,9 @@ class TelegramUpdateProcessor:
                 )
                 await self._cancel_handler(handler)
                 await self._stop_heartbeat(heartbeat)
-                await self.service.mark_failed(claimed, timeout)
+                await self.service.mark_failed(
+                    claimed, timeout, audit_context=audit_context
+                )
                 logger.error(
                     "Telegram update %s handler timed out on attempt %s",
                     claimed.update_id,
@@ -158,9 +163,13 @@ class TelegramUpdateProcessor:
                     claimed.attempts,
                     exc_info=exc,
                 )
-                await self.service.mark_failed(claimed, exc)
+                await self.service.mark_failed(
+                    claimed, exc, audit_context=audit_context
+                )
             else:
-                completed = await self.service.mark_processed(claimed)
+                completed = await self.service.mark_processed(
+                    claimed, audit_context=audit_context
+                )
                 if not completed:
                     logger.warning(
                         "Telegram update %s lost its processing lease before ACK",
@@ -175,12 +184,32 @@ class TelegramUpdateProcessor:
             await self._cancel_handler(handler)
             await self._stop_heartbeat(heartbeat)
 
-    async def _dispatch(self, claimed: ClaimedTelegramUpdate) -> None:
+    async def _dispatch(
+        self,
+        claimed: ClaimedTelegramUpdate,
+        audit_context: TelegramActionAuditContext,
+    ) -> None:
         update = Update.model_validate(
             claimed.payload,
             context={"bot": self.bot},
         )
-        await self.dispatcher.feed_update(self.bot, update)
+        parameters = inspect.signature(self.dispatcher.feed_update).parameters.values()
+        supports_workflow_data = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            or parameter.name == "telegram_action_audit"
+            for parameter in parameters
+        )
+        if supports_workflow_data:
+            await self.dispatcher.feed_update(
+                self.bot,
+                update,
+                telegram_action_audit=audit_context,
+            )
+        else:
+            # Lightweight dispatcher test doubles and legacy adapters may not
+            # expose aiogram's workflow-data kwargs. The central safe fallback
+            # remains available even without handler outcome enrichment.
+            await self.dispatcher.feed_update(self.bot, update)
 
     async def run(self) -> None:
         retry_delay = 1.0

--- a/core/db/models/__init__.py
+++ b/core/db/models/__init__.py
@@ -7,6 +7,7 @@ from .payment import ProviderPayment
 from .referral_reward import ReferralReward
 from .server import AdminAction, Server, VPNServerStatus
 from .telegram_update import TelegramUpdateInbox
+from .telegram_user_action import TelegramUserActionEvent
 from .user import User
 from .vpn_operation import VPNOperation
 
@@ -26,6 +27,7 @@ __all__ = [
     "Server",
     "VPNServerStatus",
     "TelegramUpdateInbox",
+    "TelegramUserActionEvent",
     "User",
     "VPNOperation",
 ]

--- a/core/db/models/telegram_user_action.py
+++ b/core/db/models/telegram_user_action.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import (
+    JSON,
+    BigInteger,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.db import Base
+
+
+class TelegramUserActionEvent(Base):
+    """Append-only, privacy-safe record of an input handled by the bot.
+
+    The raw Telegram update remains in the short-lived inbox only.  This table
+    deliberately stores a small allowlisted classification and never message
+    text, callback data, payment payloads, config contents, or Telegram API
+    credentials.
+    """
+
+    __tablename__ = "telegram_user_action_event"
+    __table_args__ = (
+        CheckConstraint(
+            "source_update_id >= 0",
+            name="ck_telegram_user_action_nonnegative_update_id",
+        ),
+        CheckConstraint(
+            "category = 'bot'",
+            name="ck_telegram_user_action_category",
+        ),
+        CheckConstraint(
+            "result IN ('handled', 'completed', 'rejected', 'ignored', "
+            "'invalid', 'unavailable', 'failed')",
+            name="ck_telegram_user_action_result",
+        ),
+        UniqueConstraint(
+            "source_update_id",
+            name="uq_telegram_user_action_source_update_id",
+        ),
+        Index(
+            "ix_telegram_user_action_user_occurred",
+            "user_id",
+            "occurred_at",
+            "id",
+        ),
+    )
+
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("user.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    source_update_id: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, index=True
+    )
+    category: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="bot", server_default="bot"
+    )
+    action: Mapped[str] = mapped_column(String(96), nullable=False, index=True)
+    result: Mapped[str] = mapped_column(String(24), nullable=False, index=True)
+    metadata_json: Mapped[dict] = mapped_column(
+        "metadata", JSON, nullable=False, default=dict
+    )
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=func.now(),
+        server_default=func.now(),
+        index=True,
+    )

--- a/core/db/repo/__init__.py
+++ b/core/db/repo/__init__.py
@@ -2,6 +2,7 @@ from .billing import BillingRepo
 from .config import ConfigRepo
 from .server import ServerRepo
 from .telegram_update import TelegramUpdateRepo
+from .telegram_user_action import TelegramUserActionRepo
 from .user import UserRepo
 from .vpn_operation import VPNOperationRepo
 
@@ -10,6 +11,7 @@ __all__ = [
     "ConfigRepo",
     "ServerRepo",
     "TelegramUpdateRepo",
+    "TelegramUserActionRepo",
     "UserRepo",
     "VPNOperationRepo",
 ]

--- a/core/db/repo/telegram_update.py
+++ b/core/db/repo/telegram_update.py
@@ -166,6 +166,62 @@ class TelegramUpdateRepo(BaseRepo[TelegramUpdateInbox]):
         )
         return (await self.session.execute(stmt)).scalar_one_or_none()
 
+    async def terminalize_exhausted(
+        self,
+        *,
+        now: datetime,
+        max_attempts: int,
+    ) -> list[tuple[TelegramUpdateInbox, str]]:
+        """Close exhausted rows and return them for atomic safe audit append.
+
+        ``claim_next`` retains equivalent guards for direct repository callers.
+        The bot service calls this method first so auto-DEAD transitions and
+        their immutable user-action event share one transaction.
+        """
+
+        terminalized: list[tuple[TelegramUpdateInbox, str]] = []
+        failed = (
+            update(self.model)
+            .where(
+                self.model.status == TelegramUpdateStatus.FAILED.value,
+                self.model.attempts >= max_attempts,
+            )
+            .values(
+                status=TelegramUpdateStatus.DEAD.value,
+                lease_token=None,
+                lease_until=None,
+                updated_at=now,
+            )
+            .returning(self.model)
+        )
+        terminalized.extend(
+            (row, "retry_budget_exhausted")
+            for row in (await self.session.scalars(failed)).all()
+        )
+
+        expired = (
+            update(self.model)
+            .where(
+                self.model.status == TelegramUpdateStatus.PROCESSING.value,
+                self.model.attempts >= max_attempts,
+                self.model.lease_until.is_not(None),
+                self.model.lease_until <= now,
+            )
+            .values(
+                status=TelegramUpdateStatus.DEAD.value,
+                lease_token=None,
+                lease_until=None,
+                last_error="processing lease expired after final attempt",
+                updated_at=now,
+            )
+            .returning(self.model)
+        )
+        terminalized.extend(
+            (row, "lease_expired")
+            for row in (await self.session.scalars(expired)).all()
+        )
+        return terminalized
+
     async def renew_lease(
         self,
         update_id: int,
@@ -216,21 +272,26 @@ class TelegramUpdateRepo(BaseRepo[TelegramUpdateInbox]):
         next_attempt_at: datetime,
         exhausted: bool,
     ) -> bool:
+        values = {
+            "status": (
+                TelegramUpdateStatus.DEAD.value
+                if exhausted
+                else TelegramUpdateStatus.FAILED.value
+            ),
+            "lease_token": None,
+            "lease_until": None,
+            "last_error": error[:4000],
+            "next_attempt_at": next_attempt_at,
+            "updated_at": now,
+        }
+        if exhausted:
+            # The caller already owns the in-memory payload needed for its
+            # safe classification. Do not retain raw dead-letter contents.
+            values["payload"] = {}
         stmt = (
             update(self.model)
             .where(*self._owned_processing(update_id, lease_token))
-            .values(
-                status=(
-                    TelegramUpdateStatus.DEAD.value
-                    if exhausted
-                    else TelegramUpdateStatus.FAILED.value
-                ),
-                lease_token=None,
-                lease_until=None,
-                last_error=error[:4000],
-                next_attempt_at=next_attempt_at,
-                updated_at=now,
-            )
+            .values(**values)
         )
         return bool((await self.session.execute(stmt)).rowcount)
 

--- a/core/db/repo/telegram_user_action.py
+++ b/core/db/repo/telegram_user_action.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy.exc import IntegrityError
+
+from core.db.models.telegram_user_action import TelegramUserActionEvent
+from core.exceptions import InvalidOperationError
+
+from .base import BaseRepo
+
+
+class TelegramUserActionRepo(BaseRepo[TelegramUserActionEvent]):
+    """Single append path for immutable Telegram user-action events."""
+
+    model = TelegramUserActionEvent
+
+    async def add(self, obj: TelegramUserActionEvent) -> TelegramUserActionEvent:
+        raise InvalidOperationError(
+            "Telegram user actions can only be appended through append_once"
+        )
+
+    async def delete(self, **filters) -> int:
+        raise InvalidOperationError("Telegram user action events are immutable")
+
+    async def append_once(
+        self,
+        *,
+        user_id: int,
+        source_update_id: int,
+        action: str,
+        result: str,
+        metadata: dict,
+        occurred_at: datetime,
+    ) -> tuple[TelegramUserActionEvent, bool]:
+        if source_update_id < 0:
+            raise ValueError("source_update_id must be non-negative")
+        if not action or len(action) > 96:
+            raise ValueError("invalid Telegram user action")
+        if result not in {
+            "handled",
+            "completed",
+            "rejected",
+            "ignored",
+            "invalid",
+            "unavailable",
+            "failed",
+        }:
+            raise ValueError("invalid Telegram user action result")
+
+        existing = await self.get(source_update_id=source_update_id)
+        if existing is not None:
+            return existing, False
+
+        row = self.model(
+            user_id=user_id,
+            source_update_id=source_update_id,
+            category="bot",
+            action=action,
+            result=result,
+            metadata_json=dict(metadata),
+            occurred_at=occurred_at,
+        )
+        try:
+            async with self.session.begin_nested():
+                self.session.add(row)
+                await self.session.flush()
+        except IntegrityError:
+            existing = await self.get(source_update_id=source_update_id)
+            if existing is None:
+                raise
+            return existing, False
+        return row, True

--- a/core/db/schema.py
+++ b/core/db/schema.py
@@ -1,3 +1,3 @@
 """Schema contract shared by readiness and release validation."""
 
-EXPECTED_ALEMBIC_REVISION = "d4e7f9a1b2c3"
+EXPECTED_ALEMBIC_REVISION = "e9f1a2b3c4d5"

--- a/core/db/unit_of_work.py
+++ b/core/db/unit_of_work.py
@@ -8,6 +8,7 @@ from .repo import (
     ConfigRepo,
     ServerRepo,
     TelegramUpdateRepo,
+    TelegramUserActionRepo,
     UserRepo,
     VPNOperationRepo,
 )
@@ -23,6 +24,7 @@ class Repositories(Mapping[str, object]):
     billing: BillingRepo
     vpn_operations: VPNOperationRepo
     telegram_updates: TelegramUpdateRepo
+    telegram_user_actions: TelegramUserActionRepo
 
     def __getitem__(self, key: str):
         try:
@@ -39,11 +41,12 @@ class Repositories(Mapping[str, object]):
                 "billing",
                 "vpn_operations",
                 "telegram_updates",
+                "telegram_user_actions",
             )
         )
 
     def __len__(self) -> int:
-        return 6
+        return 7
 
 
 @asynccontextmanager
@@ -56,4 +59,5 @@ async def uow():
             billing=BillingRepo(session),
             vpn_operations=VPNOperationRepo(session),
             telegram_updates=TelegramUpdateRepo(session),
+            telegram_user_actions=TelegramUserActionRepo(session),
         )

--- a/core/services/__init__.py
+++ b/core/services/__init__.py
@@ -13,7 +13,15 @@ from .payments import CryptoPaymentService, TelegramPayService
 from .referrals import ReferralOverview, ReferralService
 from .server import ServerService
 from .telegram_updates import ClaimedTelegramUpdate, TelegramUpdateService
+from .telegram_user_actions import (
+    TelegramActionAuditContext,
+    TelegramActionClassification,
+    TelegramUserActionService,
+    classify_telegram_action,
+    sanitize_action_metadata,
+)
 from .user import UserService
+from .user_timeline import AdminUserTimelineService
 from .vpn_drift import (
     VPNDriftFinding,
     VPNDriftRepairOperation,
@@ -34,6 +42,7 @@ __all__ = [
     "ManagerFleetStatus",
     "BillingService",
     "UserService",
+    "AdminUserTimelineService",
     "ServerService",
     "ConfigService",
     "TelegramPayService",
@@ -42,6 +51,11 @@ __all__ = [
     "Notification",
     "ClaimedTelegramUpdate",
     "TelegramUpdateService",
+    "TelegramActionClassification",
+    "TelegramActionAuditContext",
+    "TelegramUserActionService",
+    "classify_telegram_action",
+    "sanitize_action_metadata",
     "VPNDriftService",
     "VPNDriftFinding",
     "VPNDriftReport",

--- a/core/services/telegram_updates.py
+++ b/core/services/telegram_updates.py
@@ -10,6 +10,11 @@ from typing import Callable, Iterable
 from uuid import uuid4
 
 from core.config import settings
+from core.services.telegram_user_actions import (
+    TelegramActionAuditContext,
+    TelegramUserActionService,
+    safe_error_type,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -18,6 +23,7 @@ class ClaimedTelegramUpdate:
     payload: dict
     lease_token: str
     attempts: int
+    received_at: datetime
 
 
 class TelegramUpdateService:
@@ -76,6 +82,24 @@ class TelegramUpdateService:
         now = now or datetime.now(timezone.utc)
         lease_token = str(uuid4())
         async with self._uow() as repos:
+            terminalized = await repos.telegram_updates.terminalize_exhausted(
+                now=now,
+                max_attempts=settings.telegram_update_max_attempts,
+            )
+            for dead, terminal_reason in terminalized:
+                await TelegramUserActionService.append_in_transaction(
+                    repos,
+                    source_update_id=dead.update_id,
+                    payload=dead.payload,
+                    result="failed",
+                    occurred_at=dead.received_at,
+                    failure_metadata={
+                        "attempts": dead.attempts,
+                        "error_type": terminal_reason,
+                    },
+                )
+                # Classification is complete; dead updates never need replay.
+                dead.payload = {}
             row = await repos.telegram_updates.claim_next(
                 lease_token=lease_token,
                 now=now,
@@ -89,6 +113,7 @@ class TelegramUpdateService:
                 payload=row.payload,
                 lease_token=lease_token,
                 attempts=row.attempts,
+                received_at=row.received_at,
             )
 
     async def renew_lease(
@@ -111,14 +136,25 @@ class TelegramUpdateService:
         claimed: ClaimedTelegramUpdate,
         *,
         now: datetime | None = None,
+        audit_context: TelegramActionAuditContext | None = None,
     ) -> bool:
         now = now or datetime.now(timezone.utc)
         async with self._uow() as repos:
-            return await repos.telegram_updates.mark_processed(
+            completed = await repos.telegram_updates.mark_processed(
                 claimed.update_id,
                 lease_token=claimed.lease_token,
                 now=now,
             )
+            if completed:
+                await TelegramUserActionService.append_in_transaction(
+                    repos,
+                    source_update_id=claimed.update_id,
+                    payload=claimed.payload,
+                    result="handled",
+                    occurred_at=claimed.received_at,
+                    audit_context=audit_context,
+                )
+            return completed
 
     async def mark_failed(
         self,
@@ -126,6 +162,7 @@ class TelegramUpdateService:
         error: Exception | str,
         *,
         now: datetime | None = None,
+        audit_context: TelegramActionAuditContext | None = None,
     ) -> bool:
         now = now or datetime.now(timezone.utc)
         exhausted = claimed.attempts >= settings.telegram_update_max_attempts
@@ -134,7 +171,7 @@ class TelegramUpdateService:
             settings.telegram_update_retry_max_seconds,
         )
         async with self._uow() as repos:
-            return await repos.telegram_updates.mark_failed(
+            completed = await repos.telegram_updates.mark_failed(
                 claimed.update_id,
                 lease_token=claimed.lease_token,
                 error=f"{type(error).__name__}: {error}"[:4000],
@@ -142,6 +179,20 @@ class TelegramUpdateService:
                 next_attempt_at=now + timedelta(seconds=delay),
                 exhausted=exhausted,
             )
+            if completed and exhausted:
+                await TelegramUserActionService.append_in_transaction(
+                    repos,
+                    source_update_id=claimed.update_id,
+                    payload=claimed.payload,
+                    result="failed",
+                    occurred_at=claimed.received_at,
+                    failure_metadata={
+                        "attempts": claimed.attempts,
+                        "error_type": safe_error_type(error),
+                    },
+                    audit_context=audit_context,
+                )
+            return completed
 
     async def purge_terminal(
         self,

--- a/core/services/telegram_user_actions.py
+++ b/core/services/telegram_user_actions.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class TelegramActionClassification:
+    telegram_user_id: int | None
+    action: str
+    result: str
+    metadata: dict[str, object]
+
+
+_ALLOWED_RESULTS = frozenset(
+    {"handled", "completed", "rejected", "ignored", "invalid", "unavailable", "failed"}
+)
+_SAFE_METADATA_TYPES: dict[str, type] = {
+    "content_type": str,
+    "guide": str,
+    "direction": str,
+    "provider": str,
+    "amount_rub": int,
+    "config_id": int,
+    "server_id": int,
+    "attempts": int,
+    "error_type": str,
+    "reason_code": str,
+    "flow": str,
+}
+_SAFE_FLOW_VALUES = frozenset({"create_config", "rename_config", "none"})
+
+
+def sanitize_action_metadata(value: object) -> dict[str, object]:
+    """Allow only scalar operational fields; discard all unknown input."""
+
+    if not isinstance(value, dict):
+        return {}
+    result: dict[str, object] = {}
+    for key, expected_type in _SAFE_METADATA_TYPES.items():
+        candidate = value.get(key)
+        if isinstance(candidate, bool) or not isinstance(candidate, expected_type):
+            continue
+        if isinstance(candidate, str):
+            candidate = candidate[:64]
+            if key == "flow" and candidate not in _SAFE_FLOW_VALUES:
+                continue
+        elif candidate < 0:
+            continue
+        result[key] = candidate
+    return result
+
+
+@dataclass(slots=True)
+class TelegramActionAuditContext:
+    """Mutable, request-local outcome staged by verified bot handlers."""
+
+    action: str
+    result: str
+    metadata: dict[str, object]
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "TelegramActionAuditContext":
+        classified = classify_telegram_action(payload)
+        return cls(classified.action, classified.result, dict(classified.metadata))
+
+    def record(
+        self,
+        action: str,
+        *,
+        result: str = "completed",
+        metadata: dict[str, object] | None = None,
+    ) -> None:
+        if not action or len(action) > 96:
+            raise ValueError("invalid Telegram audit action")
+        if result not in _ALLOWED_RESULTS:
+            raise ValueError("invalid Telegram audit result")
+        self.action = action
+        self.result = result
+        self.metadata = sanitize_action_metadata(metadata or {})
+
+
+_COMMAND_ACTIONS = {
+    "start": "navigation.start",
+    "menu": "navigation.menu",
+    "help": "navigation.help",
+    "balance": "finance.balance_view",
+    "history": "finance.balance_history",
+    "configs": "vpn.config_list",
+    "topup": "finance.topup_open",
+    "how_to_use": "navigation.instructions_open",
+    "referrals": "referral.overview",
+    "create_config": "vpn.config_create_start",
+    "cancel": "navigation.cancel",
+}
+
+# These labels are inspected in memory only and are never copied to metadata.
+_MENU_ACTIONS = {
+    "💰 Баланс": "finance.balance_view",
+    "🗂 Мои конфиги": "vpn.config_list",
+    "💳 Пополнить": "finance.topup_open",
+    "📚 Инструкции": "navigation.instructions_open",
+    "🎁 Реферальная программа": "referral.overview",
+    "❌ Отмена": "navigation.cancel",
+}
+
+_GUIDES = frozenset(
+    {"menu", "windows", "macos", "android", "ios", "linux", "tv", "troubleshooting"}
+)
+_PAYMENT_PROVIDERS = frozenset({"telegram", "crypto"})
+_TOP_UP_AMOUNTS = frozenset({100, 200, 300, 500})
+_CONTENT_TYPES = (
+    "text",
+    "photo",
+    "document",
+    "audio",
+    "video",
+    "voice",
+    "video_note",
+    "animation",
+    "sticker",
+    "contact",
+    "location",
+    "venue",
+    "poll",
+    "dice",
+)
+_KNOWN_UPDATE_TYPES = frozenset(
+    {
+        "message",
+        "edited_message",
+        "channel_post",
+        "edited_channel_post",
+        "inline_query",
+        "chosen_inline_result",
+        "callback_query",
+        "shipping_query",
+        "pre_checkout_query",
+        "poll",
+        "poll_answer",
+        "my_chat_member",
+        "chat_member",
+        "chat_join_request",
+        "message_reaction",
+        "message_reaction_count",
+        "chat_boost",
+        "removed_chat_boost",
+    }
+)
+_SAFE_ERROR_TYPES = {
+    "TimeoutError": "timeout",
+    "ConnectionError": "network",
+    "TelegramNetworkError": "network",
+    "TelegramRetryAfter": "telegram_rate_limit",
+    "TelegramAPIError": "telegram_api",
+    "SQLAlchemyError": "database",
+    "OperationalError": "database",
+    "IntegrityError": "database",
+    "RuntimeError": "runtime",
+    "ValueError": "validation",
+}
+
+
+def _safe_int(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _telegram_user_id(payload: dict[str, Any]) -> int | None:
+    for update_type in (
+        "callback_query",
+        "message",
+        "edited_message",
+        "pre_checkout_query",
+        "shipping_query",
+        "inline_query",
+        "chosen_inline_result",
+        "poll_answer",
+        "chat_member",
+        "my_chat_member",
+        "chat_join_request",
+    ):
+        event = payload.get(update_type)
+        if not isinstance(event, dict):
+            continue
+        sender = event.get("from") or event.get("user")
+        if isinstance(sender, dict):
+            user_id = _safe_int(sender.get("id"))
+            if user_id is not None:
+                return user_id
+    return None
+
+
+def _message_action(message: dict[str, Any]) -> tuple[str, dict[str, object]]:
+    if isinstance(message.get("successful_payment"), dict):
+        return "finance.payment_successful", {}
+
+    text = message.get("text")
+    if isinstance(text, str):
+        if text.startswith("/"):
+            command = text.split(None, 1)[0][1:].split("@", 1)[0].casefold()
+            action = _COMMAND_ACTIONS.get(command)
+            if action is not None:
+                return action, {}
+            return "message.command_received", {}
+        action = _MENU_ACTIONS.get(text)
+        if action is not None:
+            return action, {}
+
+    content_type = next((key for key in _CONTENT_TYPES if key in message), "other")
+    return "message.received", {"content_type": content_type}
+
+
+def _callback_action(callback: dict[str, Any]) -> tuple[str, dict[str, object]]:
+    data = callback.get("data")
+    if not isinstance(data, str):
+        return "callback.received", {}
+
+    if data == "balance_summary":
+        return "finance.balance_view", {}
+    if data.startswith("balance_history:"):
+        parts = data.split(":")
+        metadata: dict[str, object] = {}
+        if len(parts) >= 2 and parts[1] in {"credit", "debit"}:
+            metadata["direction"] = parts[1]
+        return "finance.balance_history", metadata
+    if data.startswith("guide:"):
+        guide = data.partition(":")[2]
+        if guide in _GUIDES:
+            return "navigation.guide_open", {"guide": guide}
+        return "callback.received", {}
+    if data.startswith("pay:"):
+        provider = data.partition(":")[2]
+        if provider in _PAYMENT_PROVIDERS:
+            return "finance.payment_provider_select", {"provider": provider}
+        return "callback.received", {}
+    if data.startswith("topup:"):
+        raw_amount = data.partition(":")[2]
+        if raw_amount.isascii() and raw_amount.isdecimal():
+            amount = int(raw_amount)
+            if amount in _TOP_UP_AMOUNTS:
+                return "finance.payment_amount_select", {"amount_rub": amount}
+        return "callback.received", {}
+    if data.startswith("refs:"):
+        return "referral.overview", {}
+
+    exact_config_actions = {
+        "cfg:create": "vpn.config_create_start",
+        "cfg:list": "vpn.config_list",
+    }
+    if data in exact_config_actions:
+        return exact_config_actions[data], {}
+    config_patterns = (
+        (r"cfg:(\d+)", "vpn.config_view"),
+        (r"server:(\d+)", "vpn.config_server_select"),
+        (r"sus:(\d+)", "vpn.config_suspend"),
+        (r"uns:(\d+)", "vpn.config_resume"),
+        (r"del:(\d+)", "vpn.config_delete_request"),
+        (r"del_ok:(\d+)", "vpn.config_delete_confirm"),
+        (r"dl:(\d+)", "vpn.config_download"),
+        (r"rn:(\d+)", "vpn.config_rename_start"),
+    )
+    for pattern, action in config_patterns:
+        match = re.fullmatch(pattern, data)
+        if match:
+            # The numeric target is untrusted until a handler verifies
+            # ownership. A handler may add it through TelegramActionAuditContext.
+            return action, {}
+    return "callback.received", {}
+
+
+def classify_telegram_action(payload: dict[str, Any]) -> TelegramActionClassification:
+    """Reduce an untrusted Telegram update to a non-sensitive taxonomy."""
+
+    telegram_user_id = _telegram_user_id(payload)
+    message = payload.get("message")
+    if isinstance(message, dict):
+        chat = message.get("chat")
+        if isinstance(chat, dict) and chat.get("type") != "private":
+            action, metadata, result = "privacy.non_private_input", {}, "ignored"
+        else:
+            action, metadata = _message_action(message)
+            result = "handled"
+    elif isinstance(payload.get("callback_query"), dict):
+        callback = payload["callback_query"]
+        callback_message = callback.get("message")
+        chat = (
+            callback_message.get("chat") if isinstance(callback_message, dict) else None
+        )
+        if isinstance(chat, dict) and chat.get("type") != "private":
+            action, metadata, result = "privacy.non_private_input", {}, "ignored"
+        else:
+            action, metadata = _callback_action(callback)
+            result = "handled"
+    elif isinstance(payload.get("pre_checkout_query"), dict):
+        action, metadata, result = "finance.payment_pre_checkout", {}, "handled"
+    else:
+        update_type = next(
+            (
+                key
+                for key in payload
+                if key != "update_id" and key in _KNOWN_UPDATE_TYPES
+            ),
+            None,
+        )
+        action = f"{update_type}.received" if update_type else "update.received"
+        metadata = {}
+        result = "handled"
+    return TelegramActionClassification(telegram_user_id, action, result, metadata)
+
+
+def safe_error_type(error: Exception | str) -> str:
+    """Map exception classes to a small allowlist; never persist error text."""
+
+    if isinstance(error, str):
+        return "unknown"
+    for cls in type(error).__mro__:
+        mapped = _SAFE_ERROR_TYPES.get(cls.__name__)
+        if mapped is not None:
+            return mapped
+    return "unknown"
+
+
+class TelegramUserActionService:
+    """Append classified events inside the Telegram inbox transaction."""
+
+    @staticmethod
+    async def append_in_transaction(
+        repos,
+        *,
+        source_update_id: int,
+        payload: dict,
+        result: str,
+        occurred_at: datetime,
+        failure_metadata: dict[str, object] | None = None,
+        audit_context: TelegramActionAuditContext | None = None,
+    ) -> bool:
+        classification = classify_telegram_action(payload)
+        if classification.telegram_user_id is None:
+            return False
+        user = await repos.users.get_by_tg_id(classification.telegram_user_id)
+        if user is None:
+            return False
+        event_action = audit_context.action if audit_context else classification.action
+        event_result = (
+            "failed"
+            if result == "failed"
+            else (audit_context.result if audit_context else classification.result)
+        )
+        if event_result == "failed":
+            metadata_input = dict(audit_context.metadata) if audit_context else {}
+            metadata_input.update(failure_metadata or {})
+        else:
+            metadata_input = (
+                audit_context.metadata
+                if audit_context is not None
+                else classification.metadata
+            )
+        metadata = sanitize_action_metadata(metadata_input)
+        _, created = await repos.telegram_user_actions.append_once(
+            user_id=user.id,
+            source_update_id=source_update_id,
+            action=event_action,
+            result=event_result,
+            metadata=metadata,
+            occurred_at=occurred_at,
+        )
+        return created

--- a/core/services/user.py
+++ b/core/services/user.py
@@ -8,6 +8,7 @@ from sqlalchemy import select
 
 from core.db.models.ledger import LedgerEntry, LedgerKind
 from core.db.models.payment import ProviderPayment
+from core.db.models.telegram_user_action import TelegramUserActionEvent
 from core.db.models.user import User as UserModel
 from core.db.repo.billing import to_money
 from core.domain import VPNOperationKind, VPNState
@@ -140,9 +141,19 @@ class UserService:
                 .where(ProviderPayment.user_id == user_id)
                 .limit(1)
             )
-            if financial_record is not None or payment_record is not None:
-                # Financial history is immutable. A future admin use case should
-                # anonymize/disable this account instead of physically deleting it.
+            bot_audit_record = await session.scalar(
+                select(TelegramUserActionEvent.id)
+                .where(TelegramUserActionEvent.user_id == user_id)
+                .limit(1)
+            )
+            if (
+                financial_record is not None
+                or payment_record is not None
+                or bot_audit_record is not None
+            ):
+                # Financial and bot action history are immutable. A future
+                # admin use case should anonymize/disable this account instead
+                # of physically deleting it.
                 return False
 
             await repos["users"].delete(id=user_id)

--- a/core/services/user_timeline.py
+++ b/core/services/user_timeline.py
@@ -1,0 +1,760 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Callable
+
+from sqlalchemy import String, case, cast, func, literal, select
+
+from core.db.models.admin import AdminAuditEvent, AdminUser
+from core.db.models.ledger import LedgerEntry
+from core.db.models.payment import ProviderPayment
+from core.db.models.referral_reward import ReferralReward
+from core.db.models.telegram_user_action import TelegramUserActionEvent
+from core.db.models.user import User
+from core.db.models.vpn_operation import VPNOperation
+
+from .admin_queries import money, utc_iso
+
+TIMELINE_CATEGORIES = frozenset(
+    {"bot", "finance", "referral", "vpn", "admin", "account"}
+)
+TIMELINE_SOURCES = frozenset(
+    {"bot", "ledger", "payment", "referral", "vpn", "admin", "user"}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _TimelineRecord:
+    record_id: int
+    source: str
+    category: str
+    action: str
+    result: str
+    occurred_at: datetime
+    title: str
+    description: str | None
+    metadata: dict[str, object]
+    actor: dict[str, object] | None
+
+
+def _aware(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _bounded_text(value: object, *, limit: int = 500) -> str:
+    return str(value)[:limit]
+
+
+_SENSITIVE_KEYS = (
+    "password",
+    "token",
+    "secret",
+    "api_key",
+    "credential",
+    "private_key",
+    "payload",
+    "raw_data",
+    "config_content",
+    "ovpn",
+)
+
+
+def redact_admin_metadata(value: Any, *, depth: int = 0) -> Any:
+    """Recursively shape legacy audit details before returning them to admins."""
+
+    if depth >= 6:
+        return "[TRUNCATED]"
+    if isinstance(value, dict):
+        shaped = {}
+        for raw_key, nested in list(value.items())[:100]:
+            key = _bounded_text(raw_key, limit=96)
+            normalized = key.casefold()
+            if any(sensitive in normalized for sensitive in _SENSITIVE_KEYS):
+                shaped[key] = "[REDACTED]"
+            else:
+                shaped[key] = redact_admin_metadata(nested, depth=depth + 1)
+        return shaped
+    if isinstance(value, (list, tuple)):
+        return [
+            redact_admin_metadata(item, depth=depth + 1) for item in list(value)[:50]
+        ]
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, Decimal):
+        return str(value)
+    return _bounded_text(value, limit=1_000)
+
+
+_BOT_METADATA_FIELDS: dict[str, type | tuple[type, ...]] = {
+    "content_type": str,
+    "guide": str,
+    "direction": str,
+    "provider": str,
+    "amount_rub": int,
+    "config_id": int,
+    "server_id": int,
+    "attempts": int,
+    "error_type": str,
+    "reason_code": str,
+    "flow": str,
+}
+_SAFE_FLOW_VALUES = frozenset({"create_config", "rename_config", "none"})
+
+
+def shape_bot_metadata(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        return {}
+    shaped: dict[str, object] = {}
+    for key, expected_type in _BOT_METADATA_FIELDS.items():
+        candidate = value.get(key)
+        if isinstance(candidate, bool) or not isinstance(candidate, expected_type):
+            continue
+        if isinstance(candidate, str):
+            candidate = candidate[:64]
+            if key == "flow" and candidate not in _SAFE_FLOW_VALUES:
+                continue
+        elif isinstance(candidate, int):
+            candidate = max(0, candidate)
+        shaped[key] = candidate
+    return shaped
+
+
+_BOT_TITLES = {
+    "navigation.start": "Открыл бота",
+    "navigation.menu": "Открыл главное меню",
+    "navigation.help": "Открыл помощь",
+    "navigation.instructions_open": "Открыл инструкции",
+    "navigation.guide_open": "Открыл инструкцию для устройства",
+    "navigation.cancel": "Отменил действие",
+    "finance.balance_view": "Проверил баланс",
+    "finance.balance_history": "Открыл историю баланса",
+    "finance.topup_open": "Запросил пополнение баланса",
+    "finance.payment_provider_select": "Выбрал способ оплаты",
+    "finance.payment_amount_select": "Выбрал сумму пополнения",
+    "finance.payment_pre_checkout": "Проверка платежа в Telegram",
+    "finance.payment_successful": "Telegram сообщил об успешном платеже",
+    "referral.overview": "Открыл реферальную программу",
+    "vpn.config_list": "Запросил список конфигураций",
+    "vpn.config_create_start": "Запросил создание конфигурации",
+    "vpn.config_create_submit": "Отправил данные для создания конфигурации",
+    "vpn.config_server_select": "Выбрал VPN-сервер",
+    "vpn.config_view": "Запросил просмотр конфигурации",
+    "vpn.config_suspend": "Запросил приостановку конфигурации",
+    "vpn.config_resume": "Запросил возобновление конфигурации",
+    "vpn.config_delete_request": "Запросил удаление конфигурации",
+    "vpn.config_delete_confirm": "Подтвердил удаление конфигурации",
+    "vpn.config_download": "Запросил скачивание конфигурации",
+    "vpn.config_rename_start": "Начал переименование конфигурации",
+    "vpn.config_rename_submit": "Отправил новое название конфигурации",
+    "access.invite_lookup": "Открыл бота по приглашению",
+    "access.invite_required": "Попытался открыть бота без приглашения",
+    "message.unrecognized": "Отправил нераспознанное сообщение",
+    "message.received": "Отправил сообщение боту",
+    "message.command_received": "Отправил неизвестную команду",
+    "callback.received": "Нажал устаревшую или неизвестную кнопку",
+    "update.received": "Отправил событие боту",
+    "privacy.non_private_input": "Обратился к боту вне личного чата",
+}
+
+
+class AdminUserTimelineService:
+    """Build one permission-shaped, globally ordered user activity page."""
+
+    MAX_PAGE_SIZE = 100
+    MAX_OFFSET = 10_000
+
+    def __init__(self, uow: Callable):
+        self._uow = uow
+
+    async def list_timeline(
+        self,
+        user_id: int,
+        *,
+        category: str | None = None,
+        action: str | None = None,
+        result: str | None = None,
+        occurred_from: datetime | None = None,
+        occurred_to: datetime | None = None,
+        limit: int = 50,
+        offset: int = 0,
+        include_finance: bool = False,
+        include_referral: bool = False,
+        include_vpn: bool = False,
+        include_admin: bool = False,
+    ) -> dict[str, Any] | None:
+        if category is not None and category not in TIMELINE_CATEGORIES:
+            raise ValueError("invalid timeline category")
+        if occurred_from is not None:
+            occurred_from = _aware(occurred_from)
+        if occurred_to is not None:
+            occurred_to = _aware(occurred_to)
+        if occurred_from is not None and occurred_to is not None:
+            if occurred_from >= occurred_to:
+                raise ValueError("timeline 'from' must be earlier than 'to'")
+        limit = min(max(int(limit), 1), self.MAX_PAGE_SIZE)
+        offset = min(max(int(offset), 0), self.MAX_OFFSET)
+        window = offset + limit
+
+        records: list[_TimelineRecord] = []
+        total = 0
+        async with self._uow() as repos:
+            session = repos.users.session
+            user = await session.get(User, user_id)
+            if user is None:
+                return None
+
+            source_loaders = [
+                self._account_records,
+                self._bot_records,
+            ]
+            if include_finance:
+                source_loaders.extend((self._ledger_records, self._payment_records))
+            if include_referral:
+                source_loaders.append(self._referral_records)
+            if include_vpn:
+                source_loaders.append(self._vpn_records)
+            if include_admin:
+                source_loaders.append(self._admin_records)
+
+            for loader in source_loaders:
+                loaded, count = await loader(
+                    session,
+                    user,
+                    category=category,
+                    action=action,
+                    result=result,
+                    occurred_from=occurred_from,
+                    occurred_to=occurred_to,
+                    window=window,
+                )
+                records.extend(
+                    self._shape_permissions(
+                        item,
+                        include_finance=include_finance,
+                        include_vpn=include_vpn,
+                    )
+                    for item in loaded
+                )
+                total += count
+
+        source_order = {
+            "bot": 7,
+            "admin": 6,
+            "vpn": 5,
+            "payment": 4,
+            "ledger": 3,
+            "referral": 2,
+            "user": 1,
+        }
+        records.sort(
+            key=lambda item: (
+                _aware(item.occurred_at),
+                source_order[item.source],
+                item.record_id,
+            ),
+            reverse=True,
+        )
+        page = records[offset:window]
+        return {
+            "items": [self._payload(item) for item in page],
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+        }
+
+    @staticmethod
+    def _payload(item: _TimelineRecord) -> dict[str, object]:
+        return {
+            "id": f"{item.source}:{item.record_id}",
+            "source": item.source,
+            "category": item.category,
+            "action": item.action,
+            "result": item.result,
+            "occurred_at": utc_iso(item.occurred_at),
+            "title": item.title,
+            "description": item.description,
+            "metadata": item.metadata,
+            "actor": item.actor,
+        }
+
+    @staticmethod
+    def _shape_permissions(
+        item: _TimelineRecord,
+        *,
+        include_finance: bool,
+        include_vpn: bool,
+    ) -> _TimelineRecord:
+        metadata = dict(item.metadata)
+        if item.source == "bot":
+            if not include_finance:
+                for key in ("amount_rub", "provider", "direction"):
+                    metadata.pop(key, None)
+            if not include_vpn:
+                for key in ("config_id", "server_id"):
+                    metadata.pop(key, None)
+        elif (
+            item.source == "admin"
+            and item.action.startswith("balance.")
+            and not include_finance
+        ):
+            metadata = {
+                key: metadata[key]
+                for key in ("outcome", "result", "error_code", "reason_code")
+                if key in metadata
+            }
+        return replace(item, metadata=metadata)
+
+    @staticmethod
+    def _common_conditions(
+        occurred_column,
+        *,
+        occurred_from: datetime | None,
+        occurred_to: datetime | None,
+    ) -> list[Any]:
+        conditions = []
+        if occurred_from is not None:
+            conditions.append(occurred_column >= occurred_from)
+        if occurred_to is not None:
+            conditions.append(occurred_column < occurred_to)
+        return conditions
+
+    async def _account_records(
+        self,
+        session,
+        user: User,
+        *,
+        category,
+        action,
+        result,
+        occurred_from,
+        occurred_to,
+        window,
+    ):
+        if category not in (None, "account"):
+            return [], 0
+        if action not in (None, "account.created") or result not in (None, "completed"):
+            return [], 0
+        occurred = user.created
+        aware = _aware(occurred)
+        if occurred_from is not None and aware < _aware(occurred_from):
+            return [], 0
+        if occurred_to is not None and aware >= _aware(occurred_to):
+            return [], 0
+        return [
+            _TimelineRecord(
+                record_id=user.id,
+                source="user",
+                category="account",
+                action="account.created",
+                result="completed",
+                occurred_at=occurred,
+                title="Пользователь зарегистрирован",
+                description=None,
+                metadata={},
+                actor={"type": "user", "id": user.id, "label": user.username},
+            )
+        ], 1
+
+    async def _bot_records(
+        self,
+        session,
+        user: User,
+        *,
+        category,
+        action,
+        result,
+        occurred_from,
+        occurred_to,
+        window,
+    ):
+        if category not in (None, "bot"):
+            return [], 0
+        conditions = [TelegramUserActionEvent.user_id == user.id]
+        if action is not None:
+            conditions.append(TelegramUserActionEvent.action == action)
+        if result is not None:
+            conditions.append(TelegramUserActionEvent.result == result)
+        conditions.extend(
+            self._common_conditions(
+                TelegramUserActionEvent.occurred_at,
+                occurred_from=occurred_from,
+                occurred_to=occurred_to,
+            )
+        )
+        total = int(
+            await session.scalar(
+                select(func.count())
+                .select_from(TelegramUserActionEvent)
+                .where(*conditions)
+            )
+            or 0
+        )
+        rows = (
+            await session.scalars(
+                select(TelegramUserActionEvent)
+                .where(*conditions)
+                .order_by(
+                    TelegramUserActionEvent.occurred_at.desc(),
+                    TelegramUserActionEvent.id.desc(),
+                )
+                .limit(window)
+            )
+        ).all()
+        return [
+            _TimelineRecord(
+                record_id=row.id,
+                source="bot",
+                category="bot",
+                action=row.action,
+                result=row.result,
+                occurred_at=row.occurred_at,
+                title=_BOT_TITLES.get(row.action, "Действие в боте"),
+                description=None,
+                metadata=shape_bot_metadata(row.metadata_json),
+                actor={"type": "user", "id": user.id, "label": user.username},
+            )
+            for row in rows
+        ], total
+
+    async def _ledger_records(
+        self,
+        session,
+        user: User,
+        *,
+        category,
+        action,
+        result,
+        occurred_from,
+        occurred_to,
+        window,
+    ):
+        if category not in (None, "finance") or result not in (None, "completed"):
+            return [], 0
+        action_expr = literal("ledger.") + LedgerEntry.kind
+        conditions = [LedgerEntry.user_id == user.id]
+        if action is not None:
+            conditions.append(action_expr == action)
+        conditions.extend(
+            self._common_conditions(
+                LedgerEntry.created_at,
+                occurred_from=occurred_from,
+                occurred_to=occurred_to,
+            )
+        )
+        total = int(
+            await session.scalar(
+                select(func.count()).select_from(LedgerEntry).where(*conditions)
+            )
+            or 0
+        )
+        rows = (
+            await session.scalars(
+                select(LedgerEntry)
+                .where(*conditions)
+                .order_by(LedgerEntry.created_at.desc(), LedgerEntry.id.desc())
+                .limit(window)
+            )
+        ).all()
+        return [
+            _TimelineRecord(
+                record_id=row.id,
+                source="ledger",
+                category="finance",
+                action=f"ledger.{row.kind}",
+                result="completed",
+                occurred_at=row.created_at,
+                title="Начисление" if row.amount > 0 else "Списание",
+                description=None,
+                metadata={
+                    "amount": money(row.amount),
+                    "balance_after": money(row.balance_after),
+                    "kind": row.kind,
+                    "reference_type": row.reference_type,
+                },
+                actor={"type": "system"},
+            )
+            for row in rows
+        ], total
+
+    async def _payment_records(
+        self,
+        session,
+        user: User,
+        *,
+        category,
+        action,
+        result,
+        occurred_from,
+        occurred_to,
+        window,
+    ):
+        if category not in (None, "finance"):
+            return [], 0
+        occurred_expr = func.coalesce(
+            ProviderPayment.credited_at, ProviderPayment.created_at
+        )
+        action_expr = literal("payment.") + ProviderPayment.status
+        conditions = [ProviderPayment.user_id == user.id]
+        if action is not None:
+            conditions.append(action_expr == action)
+        if result is not None:
+            conditions.append(ProviderPayment.status == result)
+        conditions.extend(
+            self._common_conditions(
+                occurred_expr,
+                occurred_from=occurred_from,
+                occurred_to=occurred_to,
+            )
+        )
+        total = int(
+            await session.scalar(
+                select(func.count()).select_from(ProviderPayment).where(*conditions)
+            )
+            or 0
+        )
+        rows = (
+            await session.scalars(
+                select(ProviderPayment)
+                .where(*conditions)
+                .order_by(occurred_expr.desc(), ProviderPayment.id.desc())
+                .limit(window)
+            )
+        ).all()
+        return [
+            _TimelineRecord(
+                record_id=row.id,
+                source="payment",
+                category="finance",
+                action=f"payment.{row.status}",
+                result=row.status,
+                occurred_at=row.credited_at or row.created_at,
+                title=(
+                    "Платёж зачислен" if row.status == "credited" else "Платёж создан"
+                ),
+                description=None,
+                metadata={
+                    "amount": money(row.amount),
+                    "currency": row.currency,
+                    "provider": row.provider,
+                    "referral_settlement_status": row.referral_settlement_status,
+                },
+                actor={"type": "system"},
+            )
+            for row in rows
+        ], total
+
+    async def _referral_records(
+        self,
+        session,
+        user: User,
+        *,
+        category,
+        action,
+        result,
+        occurred_from,
+        occurred_to,
+        window,
+    ):
+        if category not in (None, "referral") or result not in (None, "completed"):
+            return [], 0
+        action_expr = literal("referral.reward_l") + cast(ReferralReward.level, String)
+        conditions = [ReferralReward.beneficiary_user_id == user.id]
+        if action is not None:
+            conditions.append(action_expr == action)
+        conditions.extend(
+            self._common_conditions(
+                ReferralReward.created_at,
+                occurred_from=occurred_from,
+                occurred_to=occurred_to,
+            )
+        )
+        total = int(
+            await session.scalar(
+                select(func.count()).select_from(ReferralReward).where(*conditions)
+            )
+            or 0
+        )
+        rows = (
+            await session.scalars(
+                select(ReferralReward)
+                .where(*conditions)
+                .order_by(ReferralReward.created_at.desc(), ReferralReward.id.desc())
+                .limit(window)
+            )
+        ).all()
+        return [
+            _TimelineRecord(
+                record_id=row.id,
+                source="referral",
+                category="referral",
+                action=f"referral.reward_l{row.level}",
+                result="completed",
+                occurred_at=row.created_at,
+                title=f"Реферальное начисление · уровень {row.level}",
+                description=None,
+                metadata={
+                    "level": row.level,
+                    "rate_bps": row.rate_bps,
+                    "source_user_id": row.source_user_id,
+                    "source_amount": money(row.source_amount),
+                    "reward_amount": money(row.reward_amount),
+                    "currency": row.currency,
+                    "program_version": row.program_version,
+                },
+                actor={"type": "system"},
+            )
+            for row in rows
+        ], total
+
+    async def _vpn_records(
+        self,
+        session,
+        user: User,
+        *,
+        category,
+        action,
+        result,
+        occurred_from,
+        occurred_to,
+        window,
+    ):
+        if category not in (None, "vpn"):
+            return [], 0
+        action_expr = literal("vpn.") + VPNOperation.kind
+        conditions = [VPNOperation.owner_id == user.id]
+        if action is not None:
+            conditions.append(action_expr == action)
+        if result is not None:
+            conditions.append(VPNOperation.status == result)
+        conditions.extend(
+            self._common_conditions(
+                VPNOperation.created_at,
+                occurred_from=occurred_from,
+                occurred_to=occurred_to,
+            )
+        )
+        total = int(
+            await session.scalar(
+                select(func.count()).select_from(VPNOperation).where(*conditions)
+            )
+            or 0
+        )
+        rows = (
+            await session.scalars(
+                select(VPNOperation)
+                .where(*conditions)
+                .order_by(VPNOperation.created_at.desc(), VPNOperation.id.desc())
+                .limit(window)
+            )
+        ).all()
+        return [
+            _TimelineRecord(
+                record_id=row.id,
+                source="vpn",
+                category="vpn",
+                action=f"vpn.{row.kind}",
+                result=row.status,
+                occurred_at=row.created_at,
+                title="Операция с VPN-конфигурацией",
+                description=None,
+                metadata={
+                    "operation_id": row.operation_id,
+                    "config_id": row.config_id,
+                    "server_id": row.server_id,
+                    "kind": row.kind,
+                    "attempts": row.attempts,
+                },
+                actor={"type": "system"},
+            )
+            for row in rows
+        ], total
+
+    async def _admin_records(
+        self,
+        session,
+        user: User,
+        *,
+        category,
+        action,
+        result,
+        occurred_from,
+        occurred_to,
+        window,
+    ):
+        if category not in (None, "admin"):
+            return [], 0
+        result_expr = func.coalesce(
+            AdminAuditEvent.details["outcome"].as_string(),
+            AdminAuditEvent.details["result"].as_string(),
+            case(
+                (AdminAuditEvent.action.like("%.failed"), "failed"),
+                else_="completed",
+            ),
+        )
+        conditions = [
+            AdminAuditEvent.target_type == "user",
+            AdminAuditEvent.target_id == str(user.id),
+        ]
+        if action is not None:
+            conditions.append(AdminAuditEvent.action == action)
+        if result is not None:
+            conditions.append(result_expr == result)
+        conditions.extend(
+            self._common_conditions(
+                AdminAuditEvent.created_at,
+                occurred_from=occurred_from,
+                occurred_to=occurred_to,
+            )
+        )
+        total = int(
+            await session.scalar(
+                select(func.count()).select_from(AdminAuditEvent).where(*conditions)
+            )
+            or 0
+        )
+        rows = (
+            await session.execute(
+                select(AdminAuditEvent, AdminUser.username.label("actor_username"))
+                .outerjoin(AdminUser, AdminUser.id == AdminAuditEvent.actor_user_id)
+                .where(*conditions)
+                .order_by(AdminAuditEvent.created_at.desc(), AdminAuditEvent.id.desc())
+                .limit(window)
+            )
+        ).all()
+        result_records = []
+        for joined in rows:
+            row = joined.AdminAuditEvent
+            details = redact_admin_metadata(dict(row.details or {}))
+            event_result = (
+                details.get("outcome")
+                or details.get("result")
+                or ("failed" if row.action.endswith(".failed") else "completed")
+            )
+            actor = (
+                {
+                    "type": "admin",
+                    "id": row.actor_user_id,
+                    "label": joined.actor_username,
+                }
+                if row.actor_user_id is not None
+                else {"type": "system"}
+            )
+            result_records.append(
+                _TimelineRecord(
+                    record_id=row.id,
+                    source="admin",
+                    category="admin",
+                    action=row.action,
+                    result=_bounded_text(event_result, limit=32),
+                    occurred_at=row.created_at,
+                    title="Действие администратора",
+                    description=None,
+                    metadata=details,
+                    actor=actor,
+                )
+            )
+        return result_records, total

--- a/deploy/activate_admin_hub.sh
+++ b/deploy/activate_admin_hub.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 umask 077
 
-readonly EXPECTED_REVISION="d4e7f9a1b2c3"
+readonly EXPECTED_REVISION="e9f1a2b3c4d5"
 readonly POSTGRES_EXPORTER_ROLE="vpn_exporter"
 readonly -a HUB_SERVICES=(admin admin_frontend nginx)
 readonly -a MONITORING_SERVICES=(

--- a/deploy/preflight.sql
+++ b/deploy/preflight.sql
@@ -9,7 +9,7 @@ BEGIN
       INTO revision_count, current_revision
       FROM alembic_version;
 
-    IF revision_count <> 1 OR current_revision <> 'd4e7f9a1b2c3' THEN
+    IF revision_count <> 1 OR current_revision <> 'e9f1a2b3c4d5' THEN
         RAISE EXCEPTION 'unexpected Alembic revision: %', current_revision;
     END IF;
 

--- a/deploy/production_canary.sh
+++ b/deploy/production_canary.sh
@@ -4,8 +4,8 @@ set -Eeuo pipefail
 umask 077
 
 readonly POSTGRES_IMAGE="postgres:16@sha256:5a65324fe84dc41709ff914e90b07f3e2f577073ed27bf917d4873aca0c9ec51"
-readonly EXPECTED_REVISION="d4e7f9a1b2c3"
-readonly EXPECTED_PREVIOUS_REVISION="f1a8c3d9e742"
+readonly EXPECTED_REVISION="e9f1a2b3c4d5"
+readonly EXPECTED_PREVIOUS_REVISION="d4e7f9a1b2c3"
 readonly POSTGRES_EXPORTER_ROLE="vpn_exporter"
 
 log() {

--- a/deploy/promote_full_production.sh
+++ b/deploy/promote_full_production.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 umask 077
 
-readonly EXPECTED_REVISION="d4e7f9a1b2c3"
+readonly EXPECTED_REVISION="e9f1a2b3c4d5"
 readonly -a MONITORING_SERVICES=(
     statsd_exporter
     postgres_exporter

--- a/docs/production-rollout.md
+++ b/docs/production-rollout.md
@@ -163,12 +163,16 @@ docker compose --env-file .env --env-file release.env \
   --entrypoint alembic migrations check
 ```
 
-The sole current revision must be `d4e7f9a1b2c3`. Before starting any
+The sole current revision must be `e9f1a2b3c4d5`. Before starting any
 application process, reconcile `user.balance` against `sum(ledger_entry.amount)`,
 verify every user has one unique 32-character referral code, and confirm that
 the admin/fleet migrations did not change user, configuration, or aggregate
-balance counts. Perform the read-only Manager smoke test and start only the bot
-canary, leaving admin, worker, and scheduler off:
+balance counts. The Telegram action journal intentionally has no historical
+backfill because processed inbox payloads have already been erased. Bot actions
+start accumulating after this migration; existing finance, referral, VPN,
+account, and admin events appear in the unified timeline immediately. Perform
+the read-only Manager smoke test and start only the bot canary, leaving admin,
+worker, and scheduler off:
 
 ```bash
 docker compose --env-file .env --env-file release.env \
@@ -201,7 +205,7 @@ environment approval; no image is rebuilt or uploaded at this stage.
 On the host, `promote_full_production.sh` acquires the same deployment lock and
 requires both `current-release` and `current-admin-hub` to equal the requested
 full SHA. It also requires the immutable staged manifest to remain fail-closed,
-the database to be at `d4e7f9a1b2c3`, all staged images and running canary
+the database to be at `e9f1a2b3c4d5`, all staged images and running canary
 containers to match their registry digests and revision labels, and both
 Manager and Telegram read-only smokes to pass.
 
@@ -233,8 +237,8 @@ periods can run as soon as the worker and scheduler are enabled.
 
 ## Rollback
 
-Prefer a code-only rollback while retaining schema head. After admin/fleet
-migration `d4e7f9a1b2c3`, keep the admin control plane stopped unless its image
+Prefer a code-only rollback while retaining schema head. After Telegram action
+audit migration `e9f1a2b3c4d5`, keep the admin control plane stopped unless its image
 understands database sessions, audit immutability and fleet lifecycle fields.
 Any bot fallback must still understand referral migration `f1a8c3d9e742`;
 pre-referral images cannot register users safely. Older production code also

--- a/tests/test_bot_action_instrumentation.py
+++ b/tests/test_bot_action_instrumentation.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from aiogram.types import Chat, Message, User
+
+from bot.handlers import (
+    balance_history,
+    common,
+    configs,
+    fallback,
+    navigation,
+    payments,
+    privacy,
+    referrals,
+)
+from bot.middlewares.invite_access import InviteOnlyAccessMiddleware
+from core.services import BalanceHistoryPage, TelegramActionAuditContext
+
+
+class DummyMessage:
+    def __init__(self, text: str | None = None, *, chat_type: str = "private"):
+        self.text = text
+        self.from_user = SimpleNamespace(id=101, username="alice")
+        self.chat = SimpleNamespace(id=202, type=chat_type)
+        self.bot = object()
+        self.calls: list[tuple[str, dict]] = []
+        self.edits: list[tuple[str, dict]] = []
+
+    async def answer(self, text: str, **kwargs):
+        self.calls.append((text, kwargs))
+
+    async def edit_text(self, text: str, **kwargs):
+        self.edits.append((text, kwargs))
+
+
+class DummyCallback:
+    def __init__(self, data: str, *, chat_type: str = "private"):
+        self.data = data
+        self.from_user = SimpleNamespace(id=101, username="alice")
+        self.message = DummyMessage(chat_type=chat_type)
+        self.bot = object()
+        self.answers: list[tuple[tuple, dict]] = []
+
+    async def answer(self, *args, **kwargs):
+        self.answers.append((args, kwargs))
+
+
+def audit(action: str = "update.received") -> TelegramActionAuditContext:
+    return TelegramActionAuditContext(action=action, result="handled", metadata={})
+
+
+@pytest.mark.asyncio
+async def test_navigation_forwards_audit_context_to_nested_feature_handlers(
+    monkeypatch,
+):
+    observed = {}
+
+    async def configs_handler(message, telegram_action_audit=None):
+        observed["configs"] = telegram_action_audit
+
+    async def topup_handler(message, telegram_action_audit=None):
+        observed["topup"] = telegram_action_audit
+
+    async def create_handler(message, state, telegram_action_audit=None):
+        observed["create"] = telegram_action_audit
+
+    class State:
+        async def clear(self):
+            return None
+
+    monkeypatch.setattr(configs, "cmd_configs", configs_handler)
+    monkeypatch.setattr(payments, "cmd_topup", topup_handler)
+    monkeypatch.setattr(configs, "cmd_create_config", create_handler)
+    context = audit()
+    state = State()
+
+    await navigation.configs_navigation(DummyMessage(), state, context)
+    await navigation.top_up_navigation(DummyMessage(), state, context)
+    await navigation.create_config_navigation(DummyMessage(), state, context)
+
+    assert observed == {
+        "configs": context,
+        "topup": context,
+        "create": context,
+    }
+
+
+@pytest.mark.asyncio
+async def test_start_records_completion_without_start_payload(monkeypatch):
+    async def existing_user(*args, **kwargs):
+        return SimpleNamespace(id=7)
+
+    monkeypatch.setattr(common, "get_or_create_user", existing_user)
+    context = audit("navigation.start")
+    message = DummyMessage("/start ref_do-not-persist")
+
+    await common.cmd_start(
+        message,
+        SimpleNamespace(args="ref_do-not-persist"),
+        context,
+    )
+
+    assert context.action == "navigation.start"
+    assert context.result == "completed"
+    assert context.metadata == {}
+    assert "do-not-persist" not in repr(context)
+
+
+@pytest.mark.asyncio
+async def test_invalid_guide_and_balance_cursor_record_only_safe_reasons():
+    guide_context = audit("callback.received")
+    guide_callback = DummyCallback("guide:raw-secret-guide")
+    await common.show_guide(guide_callback, guide_context)
+
+    assert guide_context.action == "navigation.guide_open"
+    assert guide_context.result == "invalid"
+    assert guide_context.metadata == {"reason_code": "unknown_guide"}
+    assert "raw-secret-guide" not in repr(guide_context)
+
+    history_context = audit("callback.received")
+    history_callback = DummyCallback("balance_history:raw-secret-cursor")
+    await balance_history.balance_history_callback(
+        history_callback,
+        history_context,
+    )
+
+    assert history_context.action == "finance.balance_history"
+    assert history_context.result == "invalid"
+    assert history_context.metadata == {"reason_code": "invalid_cursor"}
+    assert "raw-secret-cursor" not in repr(history_context)
+
+
+@pytest.mark.asyncio
+async def test_verified_balance_history_keeps_only_direction(monkeypatch):
+    page = BalanceHistoryPage(
+        items=(),
+        total=0,
+        limit=8,
+        offset=8,
+        snapshot_id=42,
+    )
+
+    async def history(*args, **kwargs):
+        return page
+
+    monkeypatch.setattr(balance_history, "_history_for_telegram_user", history)
+    context = audit("finance.balance_history")
+    callback = DummyCallback("balance_history:debit:42:8")
+
+    await balance_history.balance_history_callback(callback, context)
+
+    assert context.action == "finance.balance_history"
+    assert context.result == "completed"
+    assert context.metadata == {"direction": "debit"}
+
+
+@pytest.mark.asyncio
+async def test_disabled_referrals_are_explicitly_unavailable(monkeypatch):
+    async def screen(**kwargs):
+        return "Referral screen", object()
+
+    monkeypatch.setattr(referrals, "_referral_screen", screen)
+    monkeypatch.setattr(referrals.settings, "referral_rewards_enabled", False)
+    context = audit("referral.overview")
+
+    await referrals.cmd_referrals(
+        DummyMessage(),
+        bot=object(),
+        telegram_action_audit=context,
+    )
+
+    assert context.action == "referral.overview"
+    assert context.result == "unavailable"
+    assert context.metadata == {"reason_code": "referral_rewards_disabled"}
+
+
+@pytest.mark.asyncio
+async def test_privacy_and_fallback_record_rejection_without_message_text():
+    privacy_context = audit("message.received")
+    await privacy.group_message(
+        DummyMessage("private balance", chat_type="group"),
+        privacy_context,
+    )
+    assert privacy_context.action == "privacy.non_private_input"
+    assert privacy_context.result == "rejected"
+    assert privacy_context.metadata == {"reason_code": "private_chat_required"}
+    assert "private balance" not in repr(privacy_context)
+
+    fallback_context = audit("message.received")
+    await fallback.unknown_text(
+        DummyMessage("raw private message"),
+        fallback_context,
+    )
+    assert fallback_context.action == "message.unrecognized"
+    assert fallback_context.result == "invalid"
+    assert fallback_context.metadata == {
+        "content_type": "text",
+        "reason_code": "unsupported_input",
+    }
+    assert "raw private message" not in repr(fallback_context)
+
+
+@pytest.mark.asyncio
+async def test_invite_middleware_records_denial_without_unknown_message_text():
+    class MissingUserService:
+        async def find_by_tg_id(self, tg_id: int, **kwargs):
+            return None
+
+    middleware = InviteOnlyAccessMiddleware(MissingUserService())
+    context = audit("message.command_received")
+    message = Message(
+        message_id=1,
+        date=datetime.now(timezone.utc),
+        chat=Chat(id=202, type="private"),
+        from_user=User(id=101, is_bot=False, first_name="Alice"),
+        text="/start raw-secret-payload",
+    )
+    called = False
+
+    async def handler(event, data):
+        nonlocal called
+        called = True
+
+    result = await middleware(
+        handler,
+        message,
+        {"telegram_action_audit": context},
+    )
+
+    assert result is None
+    assert called is False
+    assert context.action == "access.invite_required"
+    assert context.result == "rejected"
+    assert context.metadata == {"reason_code": "invite_required"}
+    assert "raw-secret-payload" not in repr(context)
+
+
+@pytest.mark.asyncio
+async def test_cancel_records_only_allowlisted_flow_before_clearing():
+    class State:
+        cleared = False
+
+        async def get_state(self):
+            return "CreateConfig:entering_name"
+
+        async def clear(self):
+            self.cleared = True
+
+    state = State()
+    context = audit("navigation.cancel")
+
+    await navigation.cancel_navigation(DummyMessage(), state, context)
+
+    assert state.cleared is True
+    assert context.action == "navigation.cancel"
+    assert context.result == "completed"
+    assert context.metadata == {"flow": "create_config"}

--- a/tests/test_bot_ui.py
+++ b/tests/test_bot_ui.py
@@ -131,7 +131,8 @@ async def test_main_action_clears_fsm_before_shared_action(monkeypatch):
     message = DummyMessage(MENU_BALANCE)
     observed = {}
 
-    async def show_balance(target):
+    async def show_balance(target, telegram_action_audit=None):
+        assert telegram_action_audit is None
         observed["state_was_cleared"] = state.cleared
         observed["message"] = target
 
@@ -223,7 +224,8 @@ async def test_dispatcher_menu_button_wins_over_active_name_state(monkeypatch):
     bot = Bot("123456:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi")
     observed = []
 
-    async def show_balance(message):
+    async def show_balance(message, telegram_action_audit=None):
+        assert telegram_action_audit is None
         observed.append(message.text)
 
     async def existing_user(tg_id, **kwargs):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -6,6 +6,7 @@ import pytest
 
 import bot.handlers as handlers
 import bot.handlers.base as handlers_base
+from core.services.telegram_user_actions import TelegramActionAuditContext
 
 
 class DummyMessage:
@@ -117,7 +118,14 @@ async def test_tempfile_used(monkeypatch):
     monkeypatch.setattr(handlers, "FSInputFile", DummyFSInputFile)
 
     update = types.SimpleNamespace(update_id=4242)
-    await handlers.got_name(msg, state, bot, update)
+    audit = TelegramActionAuditContext("message.received", "handled", {})
+    await handlers.got_name(
+        msg,
+        state,
+        bot,
+        update,
+        telegram_action_audit=audit,
+    )
 
     sent_path = bot.sent.path
     tmp_dir = tempfile.gettempdir()
@@ -132,6 +140,10 @@ async def test_tempfile_used(monkeypatch):
             "telegram:create-config:update:4242",
         )
     ]
+    assert audit.action == "vpn.config_create_submit"
+    assert audit.result == "completed"
+    assert audit.metadata == {"config_id": 5, "server_id": 1}
+    assert "../../etc/passwd" not in repr(audit.metadata)
 
 
 @pytest.mark.asyncio
@@ -269,6 +281,61 @@ async def test_show_config_contains_download(monkeypatch):
     assert any("Переименовать" in text for text in button_texts)
     assert not any("Приостановить" in text for text in button_texts)
     assert not any("Возобновить" in text for text in button_texts)
+
+
+@pytest.mark.asyncio
+async def test_foreign_config_callback_audit_does_not_persist_requested_id(monkeypatch):
+    cb = DummyCallback("del_ok:987654")
+    audit = TelegramActionAuditContext(
+        "vpn.config_delete_confirm",
+        "handled",
+        {},
+    )
+
+    async def fake_get_user(*_args, **_kwargs):
+        return types.SimpleNamespace(id=1)
+
+    async def fake_get_config(*_args, **_kwargs):
+        return types.SimpleNamespace(id=987654, owner_id=2)
+
+    monkeypatch.setattr(handlers.configs, "get_or_create_user", fake_get_user)
+    monkeypatch.setattr(handlers.config_service, "get", fake_get_config)
+
+    await handlers.configs.confirm_delete_config_cb(
+        cb,
+        telegram_action_audit=audit,
+    )
+
+    assert audit.action == "vpn.config_delete_confirm"
+    assert audit.result == "rejected"
+    assert audit.metadata == {"reason_code": "config_not_found"}
+    assert "987654" not in repr(audit.metadata)
+
+
+@pytest.mark.asyncio
+async def test_missing_server_callback_audit_does_not_persist_requested_id(monkeypatch):
+    cb = DummyCallback("server:987654")
+    audit = TelegramActionAuditContext(
+        "vpn.config_server_select",
+        "handled",
+        {},
+    )
+
+    async def fake_get_server(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(handlers.server_service, "get", fake_get_server)
+
+    await handlers.configs.choose_server(
+        cb,
+        DummyStateRename(),
+        telegram_action_audit=audit,
+    )
+
+    assert audit.action == "vpn.config_server_select"
+    assert audit.result == "unavailable"
+    assert audit.metadata == {"reason_code": "server_unavailable"}
+    assert "987654" not in repr(audit.metadata)
 
 
 class DummyCallbackDownload:

--- a/tests/test_payment_handlers.py
+++ b/tests/test_payment_handlers.py
@@ -10,6 +10,7 @@ from bot.handlers import payments
 from core.exceptions import InvalidOperationError, UserNotFoundError
 from core.services.billing import PaymentIntent
 from core.services.payments import TelegramPayService
+from core.services.telegram_user_actions import TelegramActionAuditContext
 
 
 class DummyBot:
@@ -158,10 +159,16 @@ async def test_topup_invoice_uses_persisted_intent_without_ui_change(monkeypatch
     )
     monkeypatch.setattr(payments, "TelegramPayService", PayService)
 
+    audit = TelegramActionAuditContext(
+        "finance.payment_amount_select",
+        "handled",
+        {},
+    )
     await payments.got_topup_amount(
         DummyCallback(),
         DummyBot(),
         SimpleNamespace(update_id=7001),
+        telegram_action_audit=audit,
     )
 
     assert sent["intent_args"] == {
@@ -181,6 +188,10 @@ async def test_topup_invoice_uses_persisted_intent_without_ui_change(monkeypatch
         Decimal("100.00"),
         {"payload": "topup:intent-id", "currency": "RUB"},
     )
+    assert audit.action == "finance.payment_amount_select"
+    assert audit.result == "completed"
+    assert audit.metadata == {"amount_rub": 100}
+    assert "intent-id" not in repr(audit.metadata)
 
 
 @pytest.mark.asyncio
@@ -315,9 +326,22 @@ async def test_pre_checkout_rejects_invoice_mismatch(monkeypatch):
         currency="RUB",
     )
 
-    await payments.process_pre_checkout_query(query, bot)
+    audit = TelegramActionAuditContext(
+        "finance.payment_pre_checkout",
+        "handled",
+        {},
+    )
+    await payments.process_pre_checkout_query(
+        query,
+        bot,
+        telegram_action_audit=audit,
+    )
 
     assert bot.pre_checkout_answers[0][1]["ok"] is False
+    assert audit.action == "finance.payment_pre_checkout"
+    assert audit.result == "rejected"
+    assert audit.metadata == {"reason_code": "payment_validation_failed"}
+    assert "topup:intent-id" not in repr(audit.metadata)
 
 
 @pytest.mark.asyncio

--- a/tests/test_production_canary_cleanup.sh
+++ b/tests/test_production_canary_cleanup.sh
@@ -12,8 +12,8 @@ trap 'rm -f "$EVENTS_FILE" "$RUNTIME_ENV_FILE" "$EXPORTER_SQL_FILE"' EXIT
 # shellcheck source=../deploy/production_canary.sh
 source "$REPO_ROOT/deploy/production_canary.sh"
 
-[[ "$EXPECTED_REVISION" == "d4e7f9a1b2c3" ]]
-[[ "$EXPECTED_PREVIOUS_REVISION" == "f1a8c3d9e742" ]]
+[[ "$EXPECTED_REVISION" == "e9f1a2b3c4d5" ]]
+[[ "$EXPECTED_PREVIOUS_REVISION" == "d4e7f9a1b2c3" ]]
 [[ "$POSTGRES_EXPORTER_ROLE" == "vpn_exporter" ]]
 
 interactive_smoke_count="$(

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -107,6 +107,7 @@ async def test_uow(monkeypatch, engine):
             "billing",
             "vpn_operations",
             "telegram_updates",
+            "telegram_user_actions",
         }
         await repos["users"].add(User(tg_id=1))
 

--- a/tests/test_user_timeline.py
+++ b/tests/test_user_timeline.py
@@ -1,0 +1,604 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from admin.routers.admin_v1_users import router as users_router
+from admin.security import AdminPrincipal, get_admin_principal
+from core.config import settings
+from core.db.models import (
+    AdminAuditEvent,
+    AdminRole,
+    AdminUser,
+    LedgerEntry,
+    ProviderPayment,
+    ReferralReward,
+    TelegramUpdateInbox,
+    TelegramUserActionEvent,
+    User,
+    VPNOperation,
+)
+from core.db.repo.telegram_user_action import TelegramUserActionRepo
+from core.db.unit_of_work import uow
+from core.domain.telegram import TelegramUpdateStatus
+from core.exceptions import InvalidOperationError
+from core.services.telegram_updates import TelegramUpdateService
+from core.services.telegram_user_actions import (
+    TelegramActionAuditContext,
+    classify_telegram_action,
+)
+from core.services.user import UserService
+from core.services.user_timeline import AdminUserTimelineService
+
+NOW = datetime(2026, 7, 14, 12, 0, tzinfo=timezone.utc)
+
+
+def _private_message(update_id: int, tg_id: int, text: str) -> dict:
+    return {
+        "update_id": update_id,
+        "message": {
+            "message_id": update_id,
+            "date": 1,
+            "chat": {"id": tg_id, "type": "private"},
+            "from": {"id": tg_id, "is_bot": False, "first_name": "User"},
+            "text": text,
+        },
+    }
+
+
+def test_bot_taxonomy_never_copies_untrusted_content_or_target_ids():
+    secret = "private config name and payment payload"
+    message = classify_telegram_action(_private_message(1, 100, secret))
+    assert message.action == "message.received"
+    assert message.result == "handled"
+    assert message.metadata == {"content_type": "text"}
+    assert secret not in json.dumps(message.metadata)
+
+    start = classify_telegram_action(
+        _private_message(2, 100, "/start ref_super-secret-invite")
+    )
+    assert start.action == "navigation.start"
+    assert start.metadata == {}
+
+    forged = classify_telegram_action(
+        {
+            "update_id": 3,
+            "callback_query": {
+                "id": "callback-secret",
+                "from": {"id": 100},
+                "data": "del_ok:987654321",
+                "message": {"chat": {"id": 100, "type": "private"}},
+            },
+        }
+    )
+    assert forged.action == "vpn.config_delete_confirm"
+    assert forged.metadata == {}
+
+    payment = classify_telegram_action(
+        {
+            "update_id": 4,
+            "pre_checkout_query": {
+                "id": "query-id",
+                "from": {"id": 100},
+                "invoice_payload": "topup:must-not-survive",
+                "provider_payment_charge_id": "provider-secret",
+            },
+        }
+    )
+    assert payment.action == "finance.payment_pre_checkout"
+    assert payment.metadata == {}
+
+    group = classify_telegram_action(
+        {
+            **_private_message(5, 100, "/balance"),
+            "message": {
+                **_private_message(5, 100, "/balance")["message"],
+                "chat": {"id": -100, "type": "group"},
+            },
+        }
+    )
+    assert group.action == "privacy.non_private_input"
+    assert group.result == "ignored"
+
+
+@pytest.mark.asyncio
+async def test_fenced_ack_appends_exactly_one_safe_event(sessionmaker):
+    user = await UserService(uow).register(810_001, username="timeline-user")
+    service = TelegramUpdateService(uow)
+    raw_secret = "my laptop config PRIVATE-CONTENT"
+    await service.ingest(_private_message(81, user.tg_id, raw_secret))
+    claimed = await service.claim_next(now=NOW)
+    assert claimed is not None
+
+    stale = replace(claimed, lease_token="not-the-owner")
+    assert not await service.mark_processed(stale, now=NOW)
+    async with sessionmaker() as session:
+        assert await session.scalar(select(TelegramUserActionEvent.id)) is None
+
+    context = TelegramActionAuditContext.from_payload(claimed.payload)
+    context.record(
+        "vpn.config_rename",
+        metadata={
+            "config_id": 17,
+            "payload": raw_secret,
+            "token": "bot-token",
+        },
+    )
+    assert await service.mark_processed(claimed, now=NOW, audit_context=context)
+    assert not await service.mark_processed(claimed, now=NOW, audit_context=context)
+
+    async with sessionmaker() as session:
+        events = (await session.scalars(select(TelegramUserActionEvent))).all()
+        inbox = await session.scalar(select(TelegramUpdateInbox))
+    assert len(events) == 1
+    event = events[0]
+    assert event.source_update_id == 81
+    assert event.action == "vpn.config_rename"
+    assert event.result == "completed"
+    assert event.metadata_json == {"config_id": 17}
+    assert event.occurred_at == claimed.received_at
+    assert inbox.payload == {}
+    assert raw_secret not in json.dumps(event.metadata_json)
+
+
+@pytest.mark.asyncio
+async def test_fenced_ack_and_audit_append_roll_back_as_one_transaction(
+    sessionmaker, monkeypatch
+):
+    user = await UserService(uow).register(810_010, username="atomic-user")
+    service = TelegramUpdateService(uow)
+    await service.ingest(_private_message(810, user.tg_id, "/balance"))
+    claimed = await service.claim_next(now=NOW)
+    assert claimed is not None
+
+    async def fail_append(*_args, **_kwargs):
+        raise RuntimeError("simulated audit storage failure")
+
+    monkeypatch.setattr(TelegramUserActionRepo, "append_once", fail_append)
+    with pytest.raises(RuntimeError, match="audit storage failure"):
+        await service.mark_processed(claimed, now=NOW)
+
+    async with sessionmaker() as session:
+        inbox = await session.scalar(
+            select(TelegramUpdateInbox).where(TelegramUpdateInbox.update_id == 810)
+        )
+        assert inbox.status == TelegramUpdateStatus.PROCESSING.value
+        assert inbox.payload["message"]["text"] == "/balance"
+        assert await session.scalar(select(TelegramUserActionEvent.id)) is None
+
+
+@pytest.mark.asyncio
+async def test_terminal_failures_are_safe_and_auto_dead_is_audited(
+    sessionmaker, monkeypatch
+):
+    monkeypatch.setattr(settings, "telegram_update_max_attempts", 1)
+    user = await UserService(uow).register(810_002, username="failed-user")
+    service = TelegramUpdateService(uow)
+
+    await service.ingest(
+        {
+            "update_id": 82,
+            "callback_query": {
+                "id": "secret-callback",
+                "from": {"id": user.tg_id},
+                "data": "del_ok:999999",
+                "message": {"chat": {"id": user.tg_id, "type": "private"}},
+            },
+        }
+    )
+    claimed = await service.claim_next(now=NOW)
+    assert claimed is not None
+    assert await service.mark_failed(
+        claimed,
+        RuntimeError("config body and token must not enter the audit"),
+        now=NOW,
+    )
+
+    await service.ingest(_private_message(83, user.tg_id, "another secret"))
+    crashed = await service.claim_next(now=NOW + timedelta(seconds=1))
+    assert crashed is not None
+    assert await service.claim_next(now=NOW + timedelta(seconds=302)) is None
+
+    monkeypatch.setattr(settings, "telegram_update_max_attempts", 2)
+    await service.ingest(_private_message(84, user.tg_id, "/help"))
+    lowered = await service.claim_next(now=NOW + timedelta(seconds=400))
+    assert lowered is not None
+    assert await service.mark_failed(
+        lowered,
+        RuntimeError("first retry"),
+        now=NOW + timedelta(seconds=400),
+    )
+    monkeypatch.setattr(settings, "telegram_update_max_attempts", 1)
+    assert await service.claim_next(now=NOW + timedelta(seconds=402)) is None
+
+    async with sessionmaker() as session:
+        events = (
+            await session.scalars(
+                select(TelegramUserActionEvent).order_by(
+                    TelegramUserActionEvent.source_update_id
+                )
+            )
+        ).all()
+    assert [(event.source_update_id, event.result) for event in events] == [
+        (82, "failed"),
+        (83, "failed"),
+        (84, "failed"),
+    ]
+    assert events[0].metadata_json == {"attempts": 1, "error_type": "runtime"}
+    assert events[1].metadata_json == {
+        "attempts": 1,
+        "error_type": "lease_expired",
+    }
+    assert events[2].metadata_json == {
+        "attempts": 1,
+        "error_type": "retry_budget_exhausted",
+    }
+    serialized = json.dumps([event.metadata_json for event in events])
+    assert "token must not" not in serialized
+    assert "999999" not in serialized
+
+
+async def _seed_timeline(sessionmaker):
+    async with sessionmaker() as session, session.begin():
+        source = User(tg_id=820_001, username="source", balance=Decimal("100.00"))
+        target = User(tg_id=820_002, username="target", balance=Decimal("25.00"))
+        admin = AdminUser(
+            username="ops",
+            password_hash="$2b$12$not-used",
+            role=AdminRole.OPS.value,
+        )
+        session.add_all([source, target, admin])
+        await session.flush()
+
+        target_ledger = LedgerEntry(
+            user_id=target.id,
+            amount=Decimal("20.00"),
+            balance_after=Decimal("20.00"),
+            kind="manual_top_up",
+            idempotency_key="timeline-target-ledger",
+            details={},
+            created_at=NOW + timedelta(minutes=1),
+        )
+        source_ledger = LedgerEntry(
+            user_id=source.id,
+            amount=Decimal("100.00"),
+            balance_after=Decimal("100.00"),
+            kind="provider_payment",
+            idempotency_key="timeline-source-payment-ledger",
+            details={},
+            created_at=NOW + timedelta(minutes=2),
+        )
+        reward_ledger = LedgerEntry(
+            user_id=target.id,
+            amount=Decimal("5.00"),
+            balance_after=Decimal("25.00"),
+            kind="referral_reward_l1",
+            idempotency_key="timeline-reward-ledger",
+            details={},
+            created_at=NOW + timedelta(minutes=3),
+        )
+        session.add_all([target_ledger, source_ledger, reward_ledger])
+        await session.flush()
+
+        target_payment = ProviderPayment(
+            intent_id="timeline-target-payment",
+            user_id=target.id,
+            provider="telegram",
+            amount=Decimal("300.00"),
+            currency="RUB",
+            payload="topup:private-payload",
+            raw_data={"token": "must-never-leak"},
+            status="pending",
+            created_at=NOW + timedelta(minutes=4),
+            expires_at=NOW + timedelta(hours=1),
+        )
+        source_payment = ProviderPayment(
+            intent_id="timeline-source-payment",
+            user_id=source.id,
+            provider="telegram",
+            provider_payment_id="provider-private-id",
+            amount=Decimal("100.00"),
+            currency="RUB",
+            payload="topup:source-private-payload",
+            status="credited",
+            ledger_entry_id=source_ledger.id,
+            created_at=NOW,
+            expires_at=NOW + timedelta(hours=1),
+            credited_at=NOW + timedelta(minutes=2),
+            referral_settled_at=NOW + timedelta(minutes=3),
+            referral_program_version="v1-5pct-1pct",
+            referral_settlement_status="rewarded",
+        )
+        session.add_all([target_payment, source_payment])
+        await session.flush()
+        session.add(
+            ReferralReward(
+                source_payment_id=source_payment.id,
+                source_user_id=source.id,
+                beneficiary_user_id=target.id,
+                level=1,
+                rate_bps=500,
+                source_amount=Decimal("100.00"),
+                reward_amount=Decimal("5.00"),
+                currency="RUB",
+                ledger_entry_id=reward_ledger.id,
+                created_at=NOW + timedelta(minutes=3),
+            )
+        )
+        session.add(
+            TelegramUserActionEvent(
+                user_id=target.id,
+                source_update_id=820,
+                category="bot",
+                action="finance.payment_amount_select",
+                result="handled",
+                metadata_json={
+                    "amount_rub": 300,
+                    "provider": "telegram",
+                    "direction": "credit",
+                    "config_id": 77,
+                    "server_id": 8,
+                    "payload": "must-never-leak",
+                },
+                occurred_at=NOW + timedelta(minutes=7),
+            )
+        )
+        session.add(
+            VPNOperation(
+                operation_id="82000000-0000-4000-8000-000000000001",
+                owner_id=target.id,
+                config_id=None,
+                config_name="private-config-name",
+                server_id=None,
+                kind="create",
+                payload={"config": "must-never-leak"},
+                status="succeeded",
+                attempts=1,
+                created_at=NOW + timedelta(minutes=5),
+            )
+        )
+        session.add(
+            AdminAuditEvent(
+                actor_user_id=admin.id,
+                action="balance.adjustment_applied",
+                target_type="user",
+                target_id=str(target.id),
+                request_id="timeline-request",
+                correlation_id="timeline-correlation",
+                details={
+                    "outcome": "completed",
+                    "amount": "20.00",
+                    "direction": "credit",
+                    "target_balance": "25.00",
+                    "comment": "private support note",
+                    "reason_code": "support_correction",
+                    "token": "must-never-leak",
+                },
+                created_at=NOW + timedelta(minutes=6),
+            )
+        )
+    return target, admin
+
+
+@pytest.mark.asyncio
+async def test_unified_timeline_filters_paginates_and_redacts(sessionmaker):
+    target, _ = await _seed_timeline(sessionmaker)
+    service = AdminUserTimelineService(uow)
+    page = await service.list_timeline(
+        target.id,
+        include_finance=True,
+        include_referral=True,
+        include_vpn=True,
+        include_admin=True,
+        limit=100,
+    )
+    assert page is not None
+    assert {item["source"] for item in page["items"]} == {
+        "bot",
+        "ledger",
+        "payment",
+        "referral",
+        "vpn",
+        "admin",
+        "user",
+    }
+    assert all(
+        set(item)
+        == {
+            "id",
+            "source",
+            "category",
+            "action",
+            "result",
+            "occurred_at",
+            "title",
+            "description",
+            "metadata",
+            "actor",
+        }
+        for item in page["items"]
+    )
+    serialized = json.dumps(page, ensure_ascii=False)
+    assert "private-payload" not in serialized
+    assert "must-never-leak" not in serialized
+    assert "private-config-name" not in serialized
+
+    bot = await service.list_timeline(
+        target.id,
+        category="bot",
+        action="finance.payment_amount_select",
+        result="handled",
+        occurred_from=NOW + timedelta(minutes=6),
+        occurred_to=NOW + timedelta(minutes=8),
+        include_finance=True,
+        include_vpn=True,
+    )
+    assert bot is not None and bot["total"] == 1
+    assert bot["items"][0]["id"].startswith("bot:")
+    assert bot["items"][0]["metadata"] == {
+        "direction": "credit",
+        "provider": "telegram",
+        "amount_rub": 300,
+        "config_id": 77,
+        "server_id": 8,
+    }
+
+    first = await service.list_timeline(
+        target.id,
+        include_finance=True,
+        include_referral=True,
+        include_vpn=True,
+        include_admin=True,
+        limit=2,
+        offset=0,
+    )
+    second = await service.list_timeline(
+        target.id,
+        include_finance=True,
+        include_referral=True,
+        include_vpn=True,
+        include_admin=True,
+        limit=2,
+        offset=2,
+    )
+    assert first is not None and second is not None
+    assert first["total"] == second["total"] == page["total"]
+    assert {item["id"] for item in first["items"]}.isdisjoint(
+        item["id"] for item in second["items"]
+    )
+    assert await service.list_timeline(999_999) is None
+    with pytest.raises(ValueError, match="earlier"):
+        await service.list_timeline(
+            target.id,
+            occurred_from=NOW,
+            occurred_to=NOW,
+        )
+
+
+@pytest.mark.asyncio
+async def test_timeline_permissions_shape_bot_and_admin_metadata(sessionmaker):
+    target, _ = await _seed_timeline(sessionmaker)
+    page = await AdminUserTimelineService(uow).list_timeline(
+        target.id,
+        include_finance=False,
+        include_referral=False,
+        include_vpn=False,
+        include_admin=True,
+    )
+    assert page is not None
+    assert {item["source"] for item in page["items"]} == {"bot", "admin", "user"}
+    bot = next(item for item in page["items"] if item["source"] == "bot")
+    assert bot["metadata"] == {}
+    admin = next(item for item in page["items"] if item["source"] == "admin")
+    assert admin["metadata"] == {
+        "outcome": "completed",
+        "reason_code": "support_correction",
+    }
+
+
+def _principal(role: AdminRole) -> AdminPrincipal:
+    return AdminPrincipal(
+        user_id=999,
+        username=role.value,
+        role=role,
+        session_id=1,
+        csrf_token_hash=hashlib.sha256(b"csrf").hexdigest(),
+        expires_at=NOW + timedelta(hours=1),
+    )
+
+
+@pytest.mark.asyncio
+async def test_timeline_endpoint_requires_audit_and_includes_selected_to_date(
+    sessionmaker,
+):
+    target, _ = await _seed_timeline(sessionmaker)
+
+    support_app = FastAPI()
+    support_app.include_router(users_router)
+    support_app.dependency_overrides[get_admin_principal] = lambda: _principal(
+        AdminRole.SUPPORT
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=support_app), base_url="https://admin.test"
+    ) as client:
+        denied = await client.get(f"/api/admin/v1/users/{target.id}/timeline")
+    assert denied.status_code == 403
+
+    owner_app = FastAPI()
+    owner_app.include_router(users_router)
+    owner_app.dependency_overrides[get_admin_principal] = lambda: _principal(
+        AdminRole.OWNER
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=owner_app), base_url="https://admin.test"
+    ) as client:
+        response = await client.get(
+            f"/api/admin/v1/users/{target.id}/timeline",
+            params={"category": "bot", "to": "2026-07-14"},
+        )
+        bounded = await client.get(
+            f"/api/admin/v1/users/{target.id}/timeline",
+            params={"offset": 10_001},
+        )
+        overflowing = await client.get(
+            f"/api/admin/v1/users/{target.id}/timeline",
+            params={"to": "9999-12-31"},
+        )
+    assert response.status_code == 200
+    assert response.json()["total"] == 1
+    assert bounded.status_code == 422
+    assert overflowing.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_bot_audit_history_prevents_destructive_user_delete(sessionmaker):
+    user = await UserService(uow).register(830_001, username="retained")
+    async with sessionmaker() as session, session.begin():
+        session.add(
+            TelegramUserActionEvent(
+                user_id=user.id,
+                source_update_id=830,
+                category="bot",
+                action="navigation.start",
+                result="handled",
+                metadata_json={},
+                occurred_at=NOW,
+            )
+        )
+    assert await UserService(uow).delete(user.id) is False
+    async with sessionmaker() as session:
+        assert await session.get(User, user.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_bot_action_repo_exposes_no_mutation_or_uncontrolled_add(sessionmaker):
+    user = await UserService(uow).register(830_002, username="append-only")
+    async with uow() as repos:
+        event, created = await repos.telegram_user_actions.append_once(
+            user_id=user.id,
+            source_update_id=831,
+            action="navigation.start",
+            result="handled",
+            metadata={},
+            occurred_at=NOW,
+        )
+        assert created
+        with pytest.raises(InvalidOperationError, match="only be appended"):
+            await repos.telegram_user_actions.add(event)
+        with pytest.raises(InvalidOperationError, match="immutable"):
+            await repos.telegram_user_actions.delete(id=event.id)
+
+    async with sessionmaker() as session:
+        assert await session.scalar(
+            select(TelegramUserActionEvent.id).where(
+                TelegramUserActionEvent.source_update_id == 831
+            )
+        )

--- a/tests/test_user_timeline_migration.py
+++ b/tests/test_user_timeline_migration.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+MIGRATION_PATH = (
+    Path(__file__).parents[1]
+    / "alembic"
+    / "versions"
+    / "e9f1a2b3c4d5_telegram_user_action_timeline.py"
+)
+
+
+def _migration_module():
+    spec = importlib.util.spec_from_file_location(
+        "telegram_user_action_timeline_migration", MIGRATION_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_timeline_migration_round_trips_and_enforces_idempotency_sqlite():
+    migration = _migration_module()
+    assert migration.down_revision == "d4e7f9a1b2c3"
+    engine = sa.create_engine("sqlite+pysqlite:///:memory:")
+    metadata = sa.MetaData()
+    user = sa.Table(
+        "user",
+        metadata,
+        sa.Column("id", sa.Integer(), primary_key=True),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(user.insert().values(id=1))
+        migration.op = Operations(MigrationContext.configure(connection))
+        migration.upgrade()
+
+        inspector = sa.inspect(connection)
+        assert "telegram_user_action_event" in inspector.get_table_names()
+        assert {
+            "ix_telegram_user_action_user_occurred",
+            "ix_telegram_user_action_event_action",
+            "ix_telegram_user_action_event_result",
+        }.issubset(
+            {
+                index["name"]
+                for index in inspector.get_indexes("telegram_user_action_event")
+            }
+        )
+        action = sa.table(
+            "telegram_user_action_event",
+            sa.column("id"),
+            sa.column("user_id"),
+            sa.column("source_update_id"),
+            sa.column("category"),
+            sa.column("action"),
+            sa.column("result"),
+            sa.column("metadata", sa.JSON()),
+        )
+        connection.execute(
+            sa.insert(action).values(
+                id=1,
+                user_id=1,
+                source_update_id=100,
+                category="bot",
+                action="navigation.start",
+                result="handled",
+                metadata={},
+            )
+        )
+        with pytest.raises(IntegrityError):
+            with connection.begin_nested():
+                connection.execute(
+                    sa.insert(action).values(
+                        id=2,
+                        user_id=1,
+                        source_update_id=100,
+                        category="bot",
+                        action="navigation.start",
+                        result="handled",
+                        metadata={},
+                    )
+                )
+        with pytest.raises(IntegrityError):
+            with connection.begin_nested():
+                connection.execute(
+                    sa.insert(action).values(
+                        id=3,
+                        user_id=1,
+                        source_update_id=101,
+                        category="bot",
+                        action="navigation.start",
+                        result="processed",
+                        metadata={},
+                    )
+                )
+
+        migration.downgrade()
+        assert (
+            "telegram_user_action_event" not in sa.inspect(connection).get_table_names()
+        )
+    engine.dispose()
+
+
+def test_postgres_migration_installs_all_immutability_guards():
+    migration = _migration_module()
+    executed: list[str] = []
+
+    class Dialect:
+        name = "postgresql"
+
+    class Bind:
+        dialect = Dialect()
+
+    class FakeOperations:
+        @staticmethod
+        def get_bind():
+            return Bind()
+
+        @staticmethod
+        def execute(statement):
+            executed.append(str(statement))
+
+    migration.op = FakeOperations()
+    migration._install_immutability_guard()
+    sql = "\n".join(executed)
+    assert "BEFORE UPDATE OR DELETE ON telegram_user_action_event" in sql
+    assert "BEFORE TRUNCATE ON telegram_user_action_event" in sql
+    assert "rows are immutable" in sql
+
+
+def test_timeline_migration_contains_no_secrets_or_backfilled_raw_updates():
+    source = MIGRATION_PATH.read_text()
+    assert "telegram_update_inbox" not in source
+    assert "BOT_TOKEN" not in source
+    assert "password_hash" not in source


### PR DESCRIPTION
## What changed

- adds an append-only per-user Telegram action journal with safe outcome taxonomy;
- adds a unified admin timeline for bot, finance, referral, VPN, account, and admin events;
- adds RBAC-aware metadata shaping, filters, pagination, and local-day date boundaries;
- adds PostgreSQL immutability guards and Alembic revision `e9f1a2b3c4d5`;
- instruments bot navigation, balance, payment, referral, invite, privacy, and config flows;
- updates guarded production rollout revision checks.

## Why

Operators need a reliable per-user activity view, especially for actions performed in the Telegram bot, without persisting raw messages, callback payloads, payment secrets, tokens, or VPN configuration contents.

## User and operator impact

The admin user card gains an **История** tab. Historical finance, referral, VPN, account, and admin events are visible immediately. Telegram action history starts after the migration because already-processed inbox payloads were intentionally erased.

## Validation

- backend: 358 tests with PostgreSQL;
- frontend: 19 tests, ESLint, production build;
- fresh and restored production-dump migration `d4e7f9a1b2c3 → e9f1a2b3c4d5`;
- PostgreSQL UPDATE/DELETE/TRUNCATE rejection verified;
- black, isort, compileall, diff and secret scans;
- independent release, API/RBAC, and privacy reviews.