### PR TITLE
Allow admin activation after previous release

### DIFF
--- a/deploy/activate_admin_hub.sh
+++ b/deploy/activate_admin_hub.sh
@@ -163,6 +163,27 @@ assert_exact_marker() {
     [[ "$actual" == "$expected" ]] || die "${label} marker does not match"
 }
 
+activation_marker_state() {
+    local marker="$1"
+    local expected="$2"
+    local actual
+
+    [[ -f "$marker" && ! -L "$marker" && -s "$marker" ]] \
+        || die "admin hub release marker is missing or unsafe"
+    actual="$(<"$marker")"
+    [[ "$actual" =~ ^[0-9a-f]{40}$ ]] \
+        || die "admin hub release marker is malformed"
+    if [[ "$actual" == "$expected" ]]; then
+        printf 'current\n'
+    else
+        printf 'stale\n'
+    fi
+}
+
+activation_marker_exists() {
+    [[ -e "$1" || -L "$1" ]]
+}
+
 smoke_spa_at() {
     local url="$1"
     local label="$2"
@@ -334,6 +355,7 @@ start_new_services() {
 
 main() {
     local activation_marker
+    local activation_state
     local image_ref
     local key
     local rendered_images
@@ -472,12 +494,17 @@ main() {
     [[ "$(docker inspect -f '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "$bot_container_id")" == "$RELEASE_SHA" ]] \
         || die "the running bot revision does not match the staged release"
 
-    if [[ -e "$activation_marker" ]]; then
-        assert_exact_marker "$activation_marker" "$RELEASE_SHA" "admin hub release"
-        log "admin hub release is already active; re-running read-only smokes"
-        run_smokes
-        log "admin hub activation already healthy"
-        return 0
+    if activation_marker_exists "$activation_marker"; then
+        activation_state="$(
+            activation_marker_state "$activation_marker" "$RELEASE_SHA"
+        )"
+        if [[ "$activation_state" == "current" ]]; then
+            log "admin hub release is already active; re-running read-only smokes"
+            run_smokes
+            log "admin hub activation already healthy"
+            return 0
+        fi
+        log "a stale admin hub marker will be replaced after successful smokes"
     fi
 
     for service in "${HUB_SERVICES[@]}" "${MONITORING_SERVICES[@]}"; do

--- a/docs/production-rollout.md
+++ b/docs/production-rollout.md
@@ -187,6 +187,9 @@ separate `Activate admin hub` workflow. It rechecks the exact release SHA,
 schema head, bot health, loopback HTTP contract and the configured public HTTPS
 origin. Public acceptance verifies the normal certificate/SNI path, the SPA,
 and the same-origin unauthenticated API boundary before committing the marker.
+The previous release marker may remain after the canary stops the old admin
+layer; activation replaces it atomically only after the new release passes all
+smoke tests.
 It then starts only admin, frontend, proxy and monitoring; it does not enable
 billing, payments, provisioning, notifications, worker, or scheduler.
 

--- a/tests/test_admin_hub_activation.sh
+++ b/tests/test_admin_hub_activation.sh
@@ -5,8 +5,9 @@ set -Eeuo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 EVENTS_FILE="$(mktemp)"
 MARKER_FILE="$(mktemp)"
-readonly REPO_ROOT EVENTS_FILE MARKER_FILE
-trap 'rm -f "$EVENTS_FILE" "$MARKER_FILE"' EXIT
+DANGLING_MARKER="${MARKER_FILE}.dangling"
+readonly REPO_ROOT EVENTS_FILE MARKER_FILE DANGLING_MARKER
+trap 'rm -f "$EVENTS_FILE" "$MARKER_FILE" "$DANGLING_MARKER"' EXIT
 
 # shellcheck source=../deploy/activate_admin_hub.sh
 source "$REPO_ROOT/deploy/activate_admin_hub.sh"
@@ -133,6 +134,23 @@ printf '%s\n' "$release_sha" > "$MARKER_FILE"
 assert_exact_marker "$MARKER_FILE" "$release_sha" "test release"
 if (assert_exact_marker "$MARKER_FILE" "ffffffffffffffffffffffffffffffffffffffff" "test release") 2>/dev/null; then
     fail "mismatched release marker was accepted"
+fi
+
+# A valid marker from the previous release is expected after the canary stops
+# the old admin layer. It must select the fresh activation path, while an exact
+# marker keeps the idempotent read-only smoke path.
+next_release_sha="ffffffffffffffffffffffffffffffffffffffff"
+[[ "$(activation_marker_state "$MARKER_FILE" "$release_sha")" == "current" ]]
+[[ "$(activation_marker_state "$MARKER_FILE" "$next_release_sha")" == "stale" ]]
+printf 'not-a-release-sha\n' > "$MARKER_FILE"
+if (activation_marker_state "$MARKER_FILE" "$next_release_sha") 2>/dev/null; then
+    fail "malformed admin hub marker was accepted"
+fi
+printf '%s\n' "$release_sha" > "$MARKER_FILE"
+ln -s "${MARKER_FILE}.missing" "$DANGLING_MARKER"
+activation_marker_exists "$DANGLING_MARKER"
+if (activation_marker_state "$DANGLING_MARKER" "$next_release_sha") 2>/dev/null; then
+    fail "dangling admin hub marker symlink was accepted"
 fi
 
 workflow="$REPO_ROOT/.github/workflows/activate-admin-hub.yml"


### PR DESCRIPTION
## What changed

- classifies `current-admin-hub` as current or stale instead of rejecting every valid marker from an older release;
- keeps the exact-SHA idempotent smoke-only path;
- permits a valid previous-release marker to enter the fresh activation path;
- rejects malformed, empty, unsafe, and dangling-symlink markers fail-closed;
- replaces the stale marker atomically only after all new admin and monitoring smoke tests succeed;
- documents the normal marker lifecycle and adds regression coverage.

## Root cause

The guarded bot canary intentionally stops the previous admin layer but retains its last successful `current-admin-hub` marker. The activation script treated any existing marker as if it had to match the new release SHA, so the second production deployment after introducing this workflow stopped before starting admin services.

## Production impact

The failed activation made no service changes: the new bot canary remains healthy on schema `e9f1a2b3c4d5`, while admin, billing, workers, scheduler, payments, and provisioning remain fail-closed. After this fix passes CI, the full exact-SHA release chain will be rerun.

## Validation

- `bash -n` for deployment script and regression test;
- admin activation regression;
- full production promotion regression;
- production canary cleanup regression;
- independent marker safety and failure-cleanup review.