### PR TITLE
Allow promotion after previous production release

### DIFF
--- a/deploy/promote_full_production.sh
+++ b/deploy/promote_full_production.sh
@@ -153,6 +153,27 @@ assert_exact_marker() {
     [[ "$actual" == "$expected" ]] || die "${label} marker does not match"
 }
 
+promotion_marker_state() {
+    local marker="$1"
+    local expected="$2"
+    local actual
+
+    [[ -f "$marker" && ! -L "$marker" && -s "$marker" ]] \
+        || die "full production marker is missing or unsafe"
+    actual="$(<"$marker")"
+    [[ "$actual" =~ ^[0-9a-f]{40}$ ]] \
+        || die "full production marker is malformed"
+    if [[ "$actual" == "$expected" ]]; then
+        printf 'current\n'
+    else
+        printf 'stale\n'
+    fi
+}
+
+promotion_marker_exists() {
+    [[ -e "$1" || -L "$1" ]]
+}
+
 assert_container_image() {
     local service="$1"
     local expected_image="$2"
@@ -523,6 +544,7 @@ main() {
     local revision
     local db_container_id
     local promotion_marker
+    local promotion_state
     local candidate
     local timestamp
     local backup_dir
@@ -639,14 +661,19 @@ main() {
     [[ "$revision" == "$EXPECTED_REVISION" ]] \
         || die "live schema is not at the canary-tested revision"
 
-    if [[ -e "$promotion_marker" ]]; then
-        assert_exact_marker "$promotion_marker" "$RELEASE_SHA" "full production"
-        assert_policy "$LIVE_RELEASE_ENV" promoted
-        assert_full_topology
-        run_admin_smokes
-        run_read_only_preflights
-        log "full production release is already active and healthy"
-        return 0
+    if promotion_marker_exists "$promotion_marker"; then
+        promotion_state="$(
+            promotion_marker_state "$promotion_marker" "$RELEASE_SHA"
+        )"
+        if [[ "$promotion_state" == "current" ]]; then
+            assert_policy "$LIVE_RELEASE_ENV" promoted
+            assert_full_topology
+            run_admin_smokes
+            run_read_only_preflights
+            log "full production release is already active and healthy"
+            return 0
+        fi
+        log "a stale full production marker will be replaced after successful smokes"
     fi
 
     assert_policy "$LIVE_RELEASE_ENV" staged

--- a/docs/production-rollout.md
+++ b/docs/production-rollout.md
@@ -232,6 +232,10 @@ public HTTPS, accounting, Manager mTLS and Telegram identity checks pass.
 `rq_scheduler` is force-recreated as the final service start. The script writes
 `current-production` only after every intended service is running the exact
 staged image and has loaded the promoted switches.
+The previous valid `current-production` marker may remain after a later canary
+stops the old mutation services. Promotion treats that marker as stale and
+replaces it atomically only after the new worker, bot and scheduler pass their
+checks. Malformed or unsafe markers are rejected fail-closed.
 
 Observe the durable Telegram inbox, payment intents, VPN operations, ledger,
 notification outbox, RQ registries and billing periods immediately after

--- a/tests/test_full_production_promotion.sh
+++ b/tests/test_full_production_promotion.sh
@@ -67,6 +67,27 @@ done
 if cmp -s "$STAGED" "$PROMOTED"; then
     fail "promotion did not create a distinct runtime environment"
 fi
+
+# The canary deliberately stops the previous release's mutation services while
+# retaining its last successful production marker. A valid previous SHA must
+# select a fresh promotion; only the exact SHA selects the idempotent path.
+MARKER_FILE="$TEST_ROOT/current-production-state"
+DANGLING_MARKER="$TEST_ROOT/current-production-dangling"
+release_sha="0123456789abcdef0123456789abcdef01234567"
+next_release_sha="ffffffffffffffffffffffffffffffffffffffff"
+printf '%s\n' "$release_sha" > "$MARKER_FILE"
+[[ "$(promotion_marker_state "$MARKER_FILE" "$release_sha")" == "current" ]]
+[[ "$(promotion_marker_state "$MARKER_FILE" "$next_release_sha")" == "stale" ]]
+printf 'not-a-release-sha\n' > "$MARKER_FILE"
+if (promotion_marker_state "$MARKER_FILE" "$next_release_sha") 2>/dev/null; then
+    fail "malformed full production marker was accepted"
+fi
+printf '%s\n' "$release_sha" > "$MARKER_FILE"
+ln -s "${MARKER_FILE}.missing" "$DANGLING_MARKER"
+promotion_marker_exists "$DANGLING_MARKER"
+if (promotion_marker_state "$DANGLING_MARKER" "$next_release_sha") 2>/dev/null; then
+    fail "dangling full production marker symlink was accepted"
+fi
 grep -Fx 'MAINTENANCE_MODE=true' "$STAGED" >/dev/null \
     || fail "immutable staged environment was modified"
 
@@ -177,6 +198,29 @@ mapfile -t rollback_events < <(grep '^compose ' "$EVENTS_FILE")
 if grep -Eq '<(db|redis|migrations)>' "$EVENTS_FILE"; then
     fail "rollback operated on a data or migration service"
 fi
+
+# A failed upgrade must preserve the previous release's valid marker. It is a
+# stale breadcrumb for a safe retry, not a partial marker from the new release.
+: > "$EVENTS_FILE"
+printf 'state=promoted\n' > "$LIVE_RELEASE_ENV"
+printf 'state=staged\n' > "$BACKUP_ENV"
+printf 'in-progress\n' > "$IN_PROGRESS_MARKER"
+previous_release_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+RELEASE_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+printf '%s\n' "$previous_release_sha" > "$DEPLOY_ROOT/current-production"
+restore_fail_closed_runtime
+grep -Fx 'state=staged' "$LIVE_RELEASE_ENV" >/dev/null \
+    || fail "stale-marker rollback did not restore the release environment"
+[[ ! -e "$IN_PROGRESS_MARKER" ]] \
+    || fail "stale-marker rollback left the in-progress marker behind"
+[[ -f "$DEPLOY_ROOT/current-production" && ! -L "$DEPLOY_ROOT/current-production" ]] \
+    || fail "rollback did not preserve a safe previous production marker"
+[[ "$(<"$DEPLOY_ROOT/current-production")" == "$previous_release_sha" ]] \
+    || fail "rollback did not preserve the previous production marker"
+stale_rollback_first_event="$(grep '^compose ' "$EVENTS_FILE" | head -1)"
+[[ "$stale_rollback_first_event" == \
+    'compose <--profile> <hub> <--profile> <bot> <--profile> <worker> <--profile> <billing-scheduler> <stop> <--timeout> <60> <rq_scheduler> <rq_worker> <bot> <admin>' ]] \
+    || fail "stale-marker rollback did not stop mutation services first"
 
 # The workflow has two complete gate checks: before and after environment
 # approval. It never rebuilds or uploads code and requires both host markers.


### PR DESCRIPTION
## What changed

- classify `current-production` as current or stale instead of rejecting every marker from an older valid release;
- retain the exact-SHA idempotent health-check path;
- allow a valid previous-release marker to enter fresh promotion;
- reject malformed, empty, unsafe and dangling-symlink markers before any mutation;
- replace stale marker only after worker, bot and scheduler pass all checks;
- preserve the previous successful marker if a new promotion rolls back;
- document the marker lifecycle and add regression coverage.

## Root cause

The bot canary intentionally stops the previous mutation services and restores the fail-closed staged policy, while retaining `current-production` as a breadcrumb for the last successfully promoted release. Promotion treated any existing marker as if it had to equal the new release SHA, so it stopped before starting worker, bot or scheduler.

## Production state

No mutation service was started by the failed run. Bot canary, admin hub and monitoring remain healthy on `0586f93bb82f8abce60f5422a9c153717036da13`; billing worker and scheduler remain stopped and notifications remain disabled.

## Validation

- `bash -n deploy/promote_full_production.sh tests/test_full_production_promotion.sh`
- `bash tests/test_full_production_promotion.sh`
- `bash tests/test_admin_hub_activation.sh`
- `bash tests/test_production_canary_cleanup.sh`
- `git diff --check`
- independent fail-closed marker/rollback review